### PR TITLE
Fix skill triggering so knowledge skills auto-activate before PR and issue composition

### DIFF
--- a/github-author/.claude-plugin/plugin.json
+++ b/github-author/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-author",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Enrich Claude's knowledge for authoring high-quality GitHub contributions (PRs and Issues)",
   "author": {
     "name": "Daniel Orbach"

--- a/github-author/.claude-plugin/plugin.json
+++ b/github-author/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-author",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Enrich Claude's knowledge for authoring high-quality GitHub contributions (PRs and Issues)",
   "author": {
     "name": "Daniel Orbach"

--- a/github-author/CHANGELOG.md
+++ b/github-author/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to github-author are documented in this file.
 
+## [0.2.2] - 2026-03-08
+
+### writing-pull-requests
+- Rewrite description in third person for reliable skill discovery
+- Mark as background knowledge with `user-invocable: false`
+
+### writing-issues
+- Rewrite description in third person for reliable skill discovery
+- Mark as background knowledge with `user-invocable: false`
+
+### /draft-pr
+- Restrict to manual invocation with `disable-model-invocation: true`
+- Reference writing-pull-requests skill as explicit invocation, not vague prose
+- Add `Glob` and `Skill` to allowed tools
+
+### /draft-issue
+- Restrict to manual invocation with `disable-model-invocation: true`
+- Reference writing-issues skill as explicit invocation, not vague prose
+- Add `Glob` and `Skill` to allowed tools
+
 ## [0.2.1] - 2026-03-08
 
 ### writing-pull-requests

--- a/github-author/CHANGELOG.md
+++ b/github-author/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to github-author are documented in this file.
 
+## [0.2.1] - 2026-03-08
+
+### writing-pull-requests
+- Instruct continuous-line paragraphs in `--body` content to prevent GitHub rendering hard wraps as jagged line breaks
+
+### writing-issues
+- Instruct continuous-line paragraphs in `--body` content to prevent GitHub rendering hard wraps as jagged line breaks
+
+### /draft-pr
+- Warn against hard-wrapping paragraphs when executing `gh pr create`
+
+### /draft-issue
+- Warn against hard-wrapping paragraphs when executing `gh issue create`
+
 ## [0.2.0] - 2026-02-01
 
 ### writing-pull-requests

--- a/github-author/commands/draft-issue.md
+++ b/github-author/commands/draft-issue.md
@@ -1,6 +1,7 @@
 ---
 description: Guided interview for creating well-structured GitHub issues
 allowed-tools: Read, Grep, Bash(gh:*), AskUserQuestion
+disable-model-invocation: true
 ---
 
 # Draft GitHub Issue
@@ -55,7 +56,7 @@ Ask if any existing issues relate. Prior attempts and discussions provide valuab
 
 ## Step 5: Draft Issue
 
-Apply the writing-issues skill to draft:
+Invoke the writing-issues skill to load issue authoring conventions. Then draft:
 
 1. **Title**: Present progressive verb + goal (think: "This issue is _____")
 2. **Body**: Open with why, state who/how affected, include definition of done, link related work with context

--- a/github-author/commands/draft-issue.md
+++ b/github-author/commands/draft-issue.md
@@ -1,6 +1,6 @@
 ---
 description: Guided interview for creating well-structured GitHub issues
-allowed-tools: Read, Grep, Bash(gh:*), AskUserQuestion
+allowed-tools: Read, Grep, Glob, Skill, Bash(gh:*), AskUserQuestion
 disable-model-invocation: true
 ---
 

--- a/github-author/commands/draft-issue.md
+++ b/github-author/commands/draft-issue.md
@@ -73,5 +73,5 @@ Use AskUserQuestion:
   - Revise (Let me adjust the content)
   - Cancel (Exit without creating)
 
-If "Create issue", execute `gh issue create`.
+If "Create issue", execute `gh issue create`. Avoid hard-wrapping paragraphs in the `--body` content; GitHub renders mid-paragraph newlines as literal line breaks.
 If "Revise", ask what to change and iterate.

--- a/github-author/commands/draft-pr.md
+++ b/github-author/commands/draft-pr.md
@@ -1,6 +1,7 @@
 ---
 description: Interactive PR drafting with git-first context gathering
 allowed-tools: Read, Grep, Bash(git:*), Bash(gh:*), AskUserQuestion
+disable-model-invocation: true
 ---
 
 # Draft Pull Request
@@ -65,7 +66,7 @@ If no linked issue, the description must compensate with comprehensive context.
 
 ## Step 4: Draft PR
 
-Apply the writing-pull-requests skill to draft:
+Invoke the writing-pull-requests skill to load PR authoring conventions. Then draft:
 
 1. **Identify the capability**: What does the repository do differently after this merges?
 2. **Title**: Imperative verb + capability (think: "After this PR merges, the repository will _____")

--- a/github-author/commands/draft-pr.md
+++ b/github-author/commands/draft-pr.md
@@ -91,5 +91,5 @@ Use AskUserQuestion:
   - Revise (Let me adjust the title or description)
   - Cancel (Exit without creating)
 
-If "Create PR" or "Create as draft", execute `gh pr create`.
+If "Create PR" or "Create as draft", execute `gh pr create`. Avoid hard-wrapping paragraphs in the `--body` content; GitHub renders mid-paragraph newlines as literal line breaks.
 If "Revise", ask what to change and iterate.

--- a/github-author/commands/draft-pr.md
+++ b/github-author/commands/draft-pr.md
@@ -1,6 +1,6 @@
 ---
 description: Interactive PR drafting with git-first context gathering
-allowed-tools: Read, Grep, Bash(git:*), Bash(gh:*), AskUserQuestion
+allowed-tools: Read, Grep, Glob, Skill, Bash(git:*), Bash(gh:*), AskUserQuestion
 disable-model-invocation: true
 ---
 

--- a/github-author/skills/writing-issues/SKILL.md
+++ b/github-author/skills/writing-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Writing Issues
-description: This skill should be used when the user asks to "write an issue", "draft an issue", "create a GitHub issue", "file a bug report", "submit a feature request", "track this work", or "open an issue". Also activates proactively when preparing to create an issue with `gh issue create` or when discussing work that should be tracked. Covers issue authoring for bugs, features, tasks, and discussions.
+description: Encodes GitHub issue authoring conventions including present-progressive titles, outcome-focused bodies, problem-space framing, and definition-of-done patterns. Must be loaded before composing any issue title or body, whether drafting interactively or creating programmatically with gh issue create.
 ---
 
 # Writing Issues

--- a/github-author/skills/writing-issues/SKILL.md
+++ b/github-author/skills/writing-issues/SKILL.md
@@ -215,6 +215,16 @@ For detailed guidance, consult:
 <reason>Missing functionality is a feature request, not a bug. Bugs describe incorrect behavior; features describe new capability.</reason>
 </negative>
 
+## Line Formatting for GitHub
+
+GitHub's markdown renderer treats hard newlines within a paragraph as literal line breaks. When composing `--body` content for `gh issue create`, write each paragraph as a single continuous line with no mid-sentence wraps. Newlines should only appear:
+
+- Between paragraphs (blank line)
+- Before list items, headings, or code blocks
+- Where markdown syntax requires them
+
+This differs from `git commit -m`, where hard wraps are conventional because terminals render them directly.
+
 ## Validation Checklist
 
 Before presenting the issue:

--- a/github-author/skills/writing-issues/SKILL.md
+++ b/github-author/skills/writing-issues/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Writing Issues
 description: Encodes GitHub issue authoring conventions including present-progressive titles, outcome-focused bodies, problem-space framing, and definition-of-done patterns. Must be loaded before composing any issue title or body, whether drafting interactively or creating programmatically with gh issue create.
+user-invocable: false
 ---
 
 # Writing Issues

--- a/github-author/skills/writing-pull-requests/SKILL.md
+++ b/github-author/skills/writing-pull-requests/SKILL.md
@@ -258,6 +258,16 @@ For detailed guidance, consult:
 <reason>These describe what the developer did, not what the repository now does. See `examples/bad-pr-examples.md` for comprehensive analysis.</reason>
 </negative>
 
+## Line Formatting for GitHub
+
+GitHub's markdown renderer treats hard newlines within a paragraph as literal line breaks. When composing `--body` content for `gh pr create`, write each paragraph as a single continuous line with no mid-sentence wraps. Newlines should only appear:
+
+- Between paragraphs (blank line)
+- Before list items, headings, or code blocks
+- Where markdown syntax requires them
+
+This differs from `git commit -m`, where hard wraps are conventional because terminals render them directly.
+
 ## Self-Review Checklist
 
 Before presenting the PR:

--- a/github-author/skills/writing-pull-requests/SKILL.md
+++ b/github-author/skills/writing-pull-requests/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Writing Pull Requests
 description: Encodes PR authoring conventions including imperative titles with repository-capability verbs, motivation-focused descriptions, hidden context surfacing, and prose flow guidelines. Must be loaded before composing any pull request title or description, whether drafting interactively or creating programmatically with gh pr create.
+user-invocable: false
 ---
 
 # Writing Pull Requests

--- a/github-author/skills/writing-pull-requests/SKILL.md
+++ b/github-author/skills/writing-pull-requests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Writing Pull Requests
-description: This skill should be used when the user asks to "write a PR", "draft a pull request", "create PR description", "improve PR title", "make PR easier to review", "help with pull request", or "open a PR". Also activates proactively when preparing to create a pull request with `gh pr create` or when reviewing staged changes for contribution. Covers PR authoring, titles, and descriptions.
+description: Encodes PR authoring conventions including imperative titles with repository-capability verbs, motivation-focused descriptions, hidden context surfacing, and prose flow guidelines. Must be loaded before composing any pull request title or description, whether drafting interactively or creating programmatically with gh pr create.
 ---
 
 # Writing Pull Requests


### PR DESCRIPTION
The writing-pull-requests and writing-issues skills don't auto-activate when composing PR or issue content. The model reaches for the `/draft-pr` and `/draft-issue` commands instead (which are interactive workflows) and skips loading the knowledge skills entirely.

Three factors conspire: all four components appear in the same available-skills list where commands win on name-match; skill descriptions use second-person imperative which the [official best practices][bp] say causes discovery problems; and skill descriptions quote trigger phrases that overlap with command names.

The fix applies five independent improvements:

1. Rewrite skill descriptions in third person, focusing on knowledge content rather than user trigger phrases
2. Mark knowledge skills `user-invocable: false` so they stay in context for auto-triggering but leave the slash-command menu
3. Set `disable-model-invocation: true` on commands so their descriptions exit context entirely, eliminating competition
4. Update command bodies to "Invoke" the skills (concrete model action) instead of vaguely "Apply" them, and add `Glob` + `Skill` to allowed-tools so the invocation is actually permitted
5. Drop the specific "~72 columns" number from the hard-wrap guidance to avoid the model latching onto it

[bp]: https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices