### PR TITLE
Tighten body discipline in the Go committing skill

### DIFF
--- a/golang-dev/.claude-plugin/plugin.json
+++ b/golang-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "golang-dev",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Comprehensive Go development experience - skills that elevate Claude into the ultimate Golang developer",
   "author": {
     "name": "Daniel Orbach"

--- a/golang-dev/.claude-plugin/plugin.json
+++ b/golang-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "golang-dev",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Comprehensive Go development experience - skills that elevate Claude into the ultimate Golang developer",
   "author": {
     "name": "Daniel Orbach"

--- a/golang-dev/CHANGELOG.md
+++ b/golang-dev/CHANGELOG.md
@@ -13,6 +13,14 @@ Initial release of the naming skill for Go identifiers.
 
 ## committing
 
+Tighten body discipline so the commit message stays in its lane.
+
+- Name the three layers of meaning: diff is WHAT, file comments are WHY-INTRINSIC, body is WHY-EXTRINSIC
+- Forbid paraphrasing the diff, illustrated with a worked before-and-after example
+- Introduce the stranger test as a pre-draft step that anchors body content in unanswered questions
+- Require the engineer's voice; reject agent narration and any echo of user instructions or prompts
+- Require body length to be proportional to diff complexity
+
 Initial release of the committing skill for Go-centric codebases.
 
 - Core workflow for generating commit messages matching Go team conventions

--- a/golang-dev/CHANGELOG.md
+++ b/golang-dev/CHANGELOG.md
@@ -13,6 +13,21 @@ Initial release of the naming skill for Go identifiers.
 
 ## committing
 
+Modernize skill frontmatter to use current Claude Code fields.
+
+- Split discovery hints into a dedicated `when_to_use` field and strengthen it to fire at the earliest code-task signal in a Go-centric repo, not only on commit-time keywords
+- Pre-approve read-only git inspection (`git diff`, `git log`, `git status`) via `allowed-tools` so commit drafting no longer prompts for permission on every diagnostic command
+
+Recognize Claude Code targets and refine body discipline guidance.
+
+- Add `claude:` target for CLAUDE.md, `.claude/`, and plugin manifests
+- Add `agents:` target for subagent definition files
+- Reorder body-guidelines to follow the writer's drafting sequence
+- Present all three body principles at the drafting step so the reference becomes optional
+- Single-source the body checklist in body-guidelines.md
+- Co-locate example-file tag conventions with the example files
+- Illustrate the stranger test on a parser rename diff
+
 Tighten body discipline so the commit message stays in its lane.
 
 - Name the three layers of meaning: diff is WHAT, file comments are WHY-INTRINSIC, body is WHY-EXTRINSIC

--- a/golang-dev/skills/committing/SKILL.md
+++ b/golang-dev/skills/committing/SKILL.md
@@ -115,6 +115,8 @@ Do not guess - ask when:
 
 ### 8. Write Body (If Needed)
 
+Before drafting, apply the **stranger test**: list the questions a reader who has only the diff would still have. Write only the answers. An empty list means omit the body.
+
 Consult `references/body-guidelines.md` for when and how to write commit body.
 
 Include body when:

--- a/golang-dev/skills/committing/SKILL.md
+++ b/golang-dev/skills/committing/SKILL.md
@@ -116,9 +116,11 @@ Do not guess - ask when:
 
 ### 8. Write Body (If Needed)
 
-Before drafting, apply the **stranger test**: list the questions a reader who has only the diff would still have. Write only the answers. An empty list means omit the body.
+Three principles govern every body. Apply them in order:
 
-Consult `references/body-guidelines.md` for when and how to write commit body.
+1. **Stranger test** - list the questions a reader who has only the diff would still have. Write only the answers. An empty list means omit the body.
+2. **Length echoes complexity** - a two-paragraph body on a three-line diff is suspicious. Trim until the body's weight matches the diff's weight.
+3. **Never paraphrase the diff** - if the file's own comments already explain the choices, do not restate them. The body's job is the surrounding story the diff cannot show.
 
 Include body when:
 - One-liner alone lacks sufficient context
@@ -128,6 +130,8 @@ Include body when:
 Skip body when:
 - Change is self-explanatory from one-liner + diff
 - Simple, mechanical changes (tidy, formatting)
+
+For voice, structure, and worked examples, consult `references/body-guidelines.md`.
 
 ### 9. Present for Review
 

--- a/golang-dev/skills/committing/SKILL.md
+++ b/golang-dev/skills/committing/SKILL.md
@@ -171,6 +171,7 @@ Before presenting the commit message:
 **Body (if present):**
 - [ ] Provides context NOT visible in diff
 - [ ] Does NOT paraphrase comments, doc comments, or headers in the diff
+- [ ] Length is proportional to diff complexity (no padding)
 - [ ] Plaintext only (no Markdown)
 - [ ] Lines wrapped at 72 characters
 

--- a/golang-dev/skills/committing/SKILL.md
+++ b/golang-dev/skills/committing/SKILL.md
@@ -203,30 +203,14 @@ Load these as needed based on content type:
 
 **When to load examples:**
 
-1. **Trivial changes** - Skip examples. The workflow above suffices for straightforward commits where target and verb are obvious.
-
-2. **Ambiguous target or verb** - Search examples for clues. Use grep to find similar patterns:
+1. **Trivial changes** - Skip examples. The workflow above suffices for straightforward commits.
+2. **Ambiguous target or verb** - Grep examples for similar patterns:
    ```bash
    grep -i "verb-keyword" examples/go-code-examples.md
    ```
+3. **Sparse repository history** - Load examples in full when the working repo lacks samples to learn from.
 
-3. **Sparse repository history** - Load examples in full. When the working repository lacks good commit samples to learn from, use the example files as primary reference for style and verb selection.
-
-**XML tags for selective searching:**
-
-| Tag | Purpose | Context |
-|-----|---------|---------|
-| `<example>` | Full example with context, diff, explanation | Detailed learning |
-| `<examples category="...">` | Grouped one-liners by work type | Quick verb/pattern lookup |
-| `<message>` | Commit message to emulate | Good examples; also baseline in Verb Alternatives |
-| `<better>` | Improved alternative to `<message>` | Only in Verb Alternatives section |
-| `<anti-pattern>` | What NOT to do | Anti-Patterns section |
-| `<bad>` | Bad commit message | Inside `<anti-pattern>` |
-| `<good>` | Corrected version of `<bad>` | Inside `<anti-pattern>` |
-
-**Tag relationships:**
-- `<message>` + `<better>`: In Verb Alternatives, `<message>` is acceptable, `<better>` is preferred
-- `<bad>` + `<good>`: In Anti-Patterns, `<bad>` is wrong, `<good>` is the fix
+Each example file documents its XML tag conventions at the top.
 
 ## Special Cases
 

--- a/golang-dev/skills/committing/SKILL.md
+++ b/golang-dev/skills/committing/SKILL.md
@@ -15,6 +15,7 @@ Commits tell the story of a codebase. Follow these rules for every commit:
 2. Think: "This change modifies TARGET to _____"
 3. Use plaintext only - no Markdown formatting in commit messages
 4. Respect local repository conventions while maintaining Go team style
+5. Keep the body in its lane: the diff is the WHAT, file comments are the WHY-INTRINSIC, the commit body is the WHY-EXTRINSIC
 
 ## Workflow
 

--- a/golang-dev/skills/committing/SKILL.md
+++ b/golang-dev/skills/committing/SKILL.md
@@ -167,6 +167,7 @@ Before presenting the commit message:
 
 **Body (if present):**
 - [ ] Provides context NOT visible in diff
+- [ ] Does NOT paraphrase comments, doc comments, or headers in the diff
 - [ ] Plaintext only (no Markdown)
 - [ ] Lines wrapped at 72 characters
 

--- a/golang-dev/skills/committing/SKILL.md
+++ b/golang-dev/skills/committing/SKILL.md
@@ -172,12 +172,10 @@ Before presenting the commit message:
 - [ ] No period at end
 - [ ] Within 72 characters
 
-**Body (if present):**
+**Body (if present):** Authoritative checklist lives in `references/body-guidelines.md`. At minimum verify:
 - [ ] Provides context NOT visible in diff
-- [ ] Does NOT paraphrase comments, doc comments, or headers in the diff
-- [ ] Length is proportional to diff complexity (no padding)
-- [ ] Plaintext only (no Markdown)
-- [ ] Lines wrapped at 72 characters
+- [ ] Length proportional to diff complexity
+- [ ] Plaintext, 72-char wrap, no Markdown
 
 **Overall:**
 - [ ] Will make sense in 6 months during git blame

--- a/golang-dev/skills/committing/SKILL.md
+++ b/golang-dev/skills/committing/SKILL.md
@@ -16,6 +16,7 @@ Commits tell the story of a codebase. Follow these rules for every commit:
 3. Use plaintext only - no Markdown formatting in commit messages
 4. Respect local repository conventions while maintaining Go team style
 5. Keep the body in its lane: the diff is the WHAT, file comments are the WHY-INTRINSIC, the commit body is the WHY-EXTRINSIC
+6. Write as the human engineer making the change, not as the agent executing a task - never echo prompts or instructions
 
 ## Workflow
 
@@ -177,6 +178,8 @@ Before presenting the commit message:
 - [ ] Will make sense in 6 months during git blame
 - [ ] Respects local repository conventions
 - [ ] Professional and precise language
+- [ ] Voice is the human engineer's, not the agent's
+- [ ] No echo of user instructions, prompts, or task briefs
 
 ## Reference Files
 

--- a/golang-dev/skills/committing/SKILL.md
+++ b/golang-dev/skills/committing/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: committing
-description: This skill should be used when writing commit messages in Go-centric codebases (go.mod present or known from context). Triggers on user requests like "write a commit message", "commit these changes", "generate commit", or "author a commit". Also triggers proactively when the agent completes a task and decides to commit, prepares to run git commit, or needs to craft a commit message for staged changes. Covers commits for Go packages, documentation, configs, CI, tooling, and all other files.
+description: Writes commit messages following Go team conventions for both Go packages and supporting files (docs, configs, CI, tooling) in Go-centric codebases (go.mod present or known from context).
+when_to_use: Triggers on explicit user requests like "write a commit message", "commit these changes", "generate commit", or "author a commit". Loads proactively at the EARLIEST signal that a commit will follow in a Go-centric repo (go.mod present): when Claude is asked to write code, edit files, refactor, fix a bug, implement a feature, or plan code work in such a repo; when starting any task that will produce a diff; when completing such a task; or when preparing to run git commit. Do not wait for the word "commit" to appear — in a Go codebase, commits are inevitable, and loading these conventions up front avoids a late-stage scramble for the right target and verb.
+allowed-tools: Bash(git diff:*) Bash(git log:*) Bash(git status:*)
 ---
 
 # Committing in Go Projects

--- a/golang-dev/skills/committing/SKILL.md
+++ b/golang-dev/skills/committing/SKILL.md
@@ -66,6 +66,8 @@ Apply the decision algorithm from the appropriate reference file.
 | Go package | `pkg` or `pkg/sub` | `net/http:`, `context:` |
 | Documentation | `docs:` | All `.md` files, `docs/` |
 | GitHub | `github:` | `.github/` directory |
+| Claude Code | `claude:` | `CLAUDE.md`, `.claude/`, `plugin.json` |
+| Agents | `agents:` | `agents/` directory |
 | Git config | `git:` | `.gitignore`, `.gitattributes` |
 | Dependencies | `go.mod:` | Module changes |
 | Build | `build:` | Makefile, build scripts |

--- a/golang-dev/skills/committing/examples/go-code-examples.md
+++ b/golang-dev/skills/committing/examples/go-code-examples.md
@@ -2,6 +2,22 @@
 
 Real examples from the Go standard library organized by work type.
 
+## How to Read These Examples
+
+XML tags structure each entry for selective searching:
+
+| Tag | Purpose | Context |
+|-----|---------|---------|
+| `<example>` | Full example with context, diff, explanation | Detailed learning |
+| `<examples category="...">` | Grouped one-liners by work type | Quick verb/pattern lookup |
+| `<message>` | Commit message to emulate | Good examples; also baseline in Verb Alternatives |
+| `<better>` | Improved alternative to `<message>` | Only in Verb Alternatives section |
+| `<anti-pattern>` | What NOT to do | Anti-Patterns section |
+| `<bad>` | Bad commit message | Inside `<anti-pattern>` |
+| `<good>` | Corrected version of `<bad>` | Inside `<anti-pattern>` |
+
+In Verb Alternatives, `<message>` is acceptable and `<better>` is preferred. In Anti-Patterns, `<bad>` is wrong and `<good>` is the fix.
+
 ## Examples with Full Context
 
 <example>

--- a/golang-dev/skills/committing/examples/non-go-examples.md
+++ b/golang-dev/skills/committing/examples/non-go-examples.md
@@ -80,6 +80,23 @@ Verb "label" describes the resulting action.
 <message>github: clean up issue forms</message>
 </examples>
 
+## Claude Code
+
+<examples category="claude" context="Claude Code configuration and project memory">
+<message>claude: document repository navigation conventions</message>
+<message>claude: allow npm commands without prompts</message>
+<message>claude: enforce pre-commit linting via hook</message>
+<message>claude: enable plugin auto-discovery</message>
+</examples>
+
+## Agents
+
+<examples category="agents" context="Subagent definitions">
+<message>agents: define plugin-validator for marketplace checks</message>
+<message>agents: specialize code-reviewer for security-sensitive paths</message>
+<message>agents: delegate test generation to go-test-writer</message>
+</examples>
+
 ## Git Configuration
 
 <examples category="git" context="Git configuration files (.gitignore, .gitattributes, LFS)">

--- a/golang-dev/skills/committing/examples/non-go-examples.md
+++ b/golang-dev/skills/committing/examples/non-go-examples.md
@@ -2,6 +2,8 @@
 
 Real and representative examples of commits for non-Go files in Go-centric codebases.
 
+Uses the same XML tag conventions as `go-code-examples.md`. See its "How to Read These Examples" section for the tag table.
+
 ## Examples with Full Context
 
 <example>

--- a/golang-dev/skills/committing/references/body-guidelines.md
+++ b/golang-dev/skills/committing/references/body-guidelines.md
@@ -52,7 +52,13 @@ Use `fmt -w 72` or `fold -s -w 72` to verify body text is properly wrapped.
 
 ## What to Include
 
-The body's purpose is to capture the **WHY** - context from the conversation and thought process that led to this change.
+A commit has three layers of meaning, and each lives in its own place:
+
+- **The diff is the WHAT** - the change itself, line by line.
+- **File comments are the WHY-INTRINSIC** - doc comments, header blocks, and inline notes that explain the file's own decisions. A reader sees them the moment they look at the diff.
+- **The commit body is the WHY-EXTRINSIC** - facts about the world around the diff: where this change sits in a longer sequence, what motivated doing it now, what it unlocks downstream, what alternative was rejected, what constraint forced it.
+
+Keep the body in its lane. Its job is the surrounding story the diff cannot show.
 
 ### Motivation
 

--- a/golang-dev/skills/committing/references/body-guidelines.md
+++ b/golang-dev/skills/committing/references/body-guidelines.md
@@ -110,9 +110,40 @@ TODO: Add metrics for monitoring attack patterns.
 
 Only include these when they are strictly present in the conversation context.
 
+## Never Paraphrase the Diff
+
+When the changed file carries its own rationale - header comments, doc comments, inline explanations - restating that material in the body is dead weight. The reader sees those comments the moment they look at the diff. A self-documenting file deserves a brief, outward-pointing body or no body at all. Never a paraphrase.
+
+### Worked Example: Paraphrase vs. Surrounding Story
+
+**Before** (paraphrases the file's own header about ko, defaults, base image, and platforms):
+
+```
+ko separates what to build from how. Top-level default* keys apply
+to every build; a builds: array would only override defaults per
+import path. Chainguard's static base is a minimal nonroot
+distroless-style image suitable for a fully-static Go binary with
+no CGO. Two platforms cover Linux nodes of either architecture and
+Apple Silicon developer machines.
+```
+
+Every claim above is already in the file the reader is about to scroll through. The body adds nothing.
+
+**After** (says only what the file cannot - its place in the sequence and what follows):
+
+```
+First step toward publishing the api-gateway image: the file itself
+documents the choices it encodes, and subsequent commits introduce
+the ko-based reusable workflow that consumes it plus the per-PR and
+continuous-integration wiring that drives it.
+```
+
+The replacement is shorter and tells the reader something the diff alone cannot: this is step 1 of N, and here is what step 2 looks like.
+
 ## What NOT to Include
 
 - Information visible in the diff itself
+- Paraphrases of comments, doc comments, or header blocks already in the diff
 - File listings or line-by-line implementation details
 - Markdown formatting (headers, bullets, code blocks)
 - Generic phrases like "this commit does X"
@@ -142,6 +173,7 @@ caused timeouts.
 ## Body Checklist
 
 - [ ] Provides context NOT visible in the diff
+- [ ] Does NOT paraphrase comments, doc comments, or headers in the diff
 - [ ] Plaintext only (no Markdown)
 - [ ] Lines hard-wrapped at 72 characters
 - [ ] Paragraphs separated by blank lines

--- a/golang-dev/skills/committing/references/body-guidelines.md
+++ b/golang-dev/skills/committing/references/body-guidelines.md
@@ -154,6 +154,40 @@ continuous-integration wiring that drives it.
 
 The replacement is shorter and tells the reader something the diff alone cannot: this is step 1 of N, and here is what step 2 looks like.
 
+## Authorial Voice
+
+Commit messages enter the project's permanent record. They must sound like the engineer who made the change, not like an agent narrating the task it was given.
+
+### Write as the Human Engineer
+
+The body uses the voice of the engineer who authored the change. That an agent drafted it is incidental and never belongs in the message.
+
+Bad (agent narrating its task):
+```
+I was asked to refactor the parser, so this commit replaces...
+Per the task brief, validation is now applied to...
+Following your instructions, the timeout was raised to...
+```
+
+Good (engineer describing the change):
+```
+Replaces the parser so callers receive structured errors instead of
+panicking on malformed input.
+```
+
+### Never Echo Instructions
+
+Prompts and instructions are directed AT the agent. They are not part of the project's traceability chain. The git log records what the code does and why, not what someone told the agent to do.
+
+Bad (echoing the prompt):
+```
+The user asked to add validation to login.
+As per the spec at <url>, this change introduces retries.
+The TODO file said this should be one commit, so...
+```
+
+Distil the *intent behind* the instruction into the body's WHY-EXTRINSIC, then drop the instruction itself. The reader cares why the change exists, not which side of the keyboard authored it.
+
 ## What NOT to Include
 
 - Information visible in the diff itself
@@ -161,6 +195,8 @@ The replacement is shorter and tells the reader something the diff alone cannot:
 - File listings or line-by-line implementation details
 - Markdown formatting (headers, bullets, code blocks)
 - Generic phrases like "this commit does X"
+- Agent voice ("I was asked to", "per instructions")
+- Echoes of user prompts, task briefs, or instruction documents
 
 ## Issue References
 
@@ -193,6 +229,8 @@ caused timeouts.
 - [ ] Paragraphs separated by blank lines
 - [ ] URLs wrapped in angle brackets
 - [ ] Explains WHY, not WHAT (diff shows what)
+- [ ] Voice is the human engineer's, not the agent's
+- [ ] No echo of user instructions, prompts, or task briefs
 - [ ] Will make sense in 6 months during git blame
 
 **Before finalizing:** Re-read the diff alongside the body. Delete any sentence that just describes what changed (e.g., "renamed function X to Y") - the diff already shows that. Keep only what the diff cannot tell: why, what alternatives were rejected, what comes next.

--- a/golang-dev/skills/committing/references/body-guidelines.md
+++ b/golang-dev/skills/committing/references/body-guidelines.md
@@ -17,19 +17,6 @@ Skip the body when:
 - Simple, straightforward changes with obvious motivation
 - Mechanical changes (tidy, formatting, renames)
 
-## Length Echoes Complexity
-
-A body's length should echo the diff's complexity. The body is not a place to demonstrate effort; it is a place to answer the questions the diff leaves open.
-
-Rough calibration:
-
-- One-line typo fix: no body
-- Small atomic change with a non-obvious why: one or two sentences
-- Larger restructuring or design decision: a paragraph, possibly two
-- Multi-area refactor with rejected alternatives: several paragraphs
-
-A two-paragraph body on a three-line diff is suspicious - it is almost certainly paraphrasing the diff or restating what the subject already says. Trim until the body's weight matches the diff's weight.
-
 ## Before Writing: The Stranger Test
 
 Before drafting any body, list the questions a stranger would still have after reading the diff with no other context. Write only the answers. If the list is empty, omit the body - a precise subject plus a self-documenting diff beats a body that paraphrases the diff.
@@ -43,6 +30,19 @@ Useful prompts when generating the list:
 - Where does this sit in a longer sequence of commits?
 
 Each answer earns its place in the body. Sentences that do not answer one of these questions usually duplicate the diff.
+
+## Length Echoes Complexity
+
+A body's length should echo the diff's complexity. The body is not a place to demonstrate effort; it is a place to answer the questions the diff leaves open.
+
+Rough calibration:
+
+- One-line typo fix: no body
+- Small atomic change with a non-obvious why: one or two sentences
+- Larger restructuring or design decision: a paragraph, possibly two
+- Multi-area refactor with rejected alternatives: several paragraphs
+
+A two-paragraph body on a three-line diff is suspicious - it is almost certainly paraphrasing the diff or restating what the subject already says. Trim until the body's weight matches the diff's weight.
 
 ## Format Rules
 
@@ -86,6 +86,36 @@ A commit has three layers of meaning, and each lives in its own place:
 - **The commit body is the WHY-EXTRINSIC** - facts about the world around the diff: where this change sits in a longer sequence, what motivated doing it now, what it unlocks downstream, what alternative was rejected, what constraint forced it.
 
 Keep the body in its lane. Its job is the surrounding story the diff cannot show.
+
+### Never Paraphrase the Diff
+
+When the changed file carries its own rationale - header comments, doc comments, inline explanations - restating that material in the body is dead weight. The reader sees those comments the moment they look at the diff. A self-documenting file deserves a brief, outward-pointing body or no body at all. Never a paraphrase.
+
+#### Worked Example: Paraphrase vs. Surrounding Story
+
+**Before** (paraphrases the file's own header about ko, defaults, base image, and platforms):
+
+```
+ko separates what to build from how. Top-level default* keys apply
+to every build; a builds: array would only override defaults per
+import path. Chainguard's static base is a minimal nonroot
+distroless-style image suitable for a fully-static Go binary with
+no CGO. Two platforms cover Linux nodes of either architecture and
+Apple Silicon developer machines.
+```
+
+Every claim above is already in the file the reader is about to scroll through. The body adds nothing.
+
+**After** (says only what the file cannot - its place in the sequence and what follows):
+
+```
+First step toward publishing the api-gateway image: the file itself
+documents the choices it encodes, and subsequent commits introduce
+the ko-based reusable workflow that consumes it plus the per-PR and
+continuous-integration wiring that drives it.
+```
+
+The replacement is shorter and tells the reader something the diff alone cannot: this is step 1 of N, and here is what step 2 looks like.
 
 ### Motivation
 
@@ -136,36 +166,6 @@ TODO: Add metrics for monitoring attack patterns.
 ```
 
 Only include these when they are strictly present in the conversation context.
-
-## Never Paraphrase the Diff
-
-When the changed file carries its own rationale - header comments, doc comments, inline explanations - restating that material in the body is dead weight. The reader sees those comments the moment they look at the diff. A self-documenting file deserves a brief, outward-pointing body or no body at all. Never a paraphrase.
-
-### Worked Example: Paraphrase vs. Surrounding Story
-
-**Before** (paraphrases the file's own header about ko, defaults, base image, and platforms):
-
-```
-ko separates what to build from how. Top-level default* keys apply
-to every build; a builds: array would only override defaults per
-import path. Chainguard's static base is a minimal nonroot
-distroless-style image suitable for a fully-static Go binary with
-no CGO. Two platforms cover Linux nodes of either architecture and
-Apple Silicon developer machines.
-```
-
-Every claim above is already in the file the reader is about to scroll through. The body adds nothing.
-
-**After** (says only what the file cannot - its place in the sequence and what follows):
-
-```
-First step toward publishing the api-gateway image: the file itself
-documents the choices it encodes, and subsequent commits introduce
-the ko-based reusable workflow that consumes it plus the per-PR and
-continuous-integration wiring that drives it.
-```
-
-The replacement is shorter and tells the reader something the diff alone cannot: this is step 1 of N, and here is what step 2 looks like.
 
 ## Authorial Voice
 

--- a/golang-dev/skills/committing/references/body-guidelines.md
+++ b/golang-dev/skills/committing/references/body-guidelines.md
@@ -17,6 +17,19 @@ Skip the body when:
 - Simple, straightforward changes with obvious motivation
 - Mechanical changes (tidy, formatting, renames)
 
+## Length Echoes Complexity
+
+A body's length should echo the diff's complexity. The body is not a place to demonstrate effort; it is a place to answer the questions the diff leaves open.
+
+Rough calibration:
+
+- One-line typo fix: no body
+- Small atomic change with a non-obvious why: one or two sentences
+- Larger restructuring or design decision: a paragraph, possibly two
+- Multi-area refactor with rejected alternatives: several paragraphs
+
+A two-paragraph body on a three-line diff is suspicious - it is almost certainly paraphrasing the diff or restating what the subject already says. Trim until the body's weight matches the diff's weight.
+
 ## Before Writing: The Stranger Test
 
 Before drafting any body, list the questions a stranger would still have after reading the diff with no other context. Write only the answers. If the list is empty, omit the body - a precise subject plus a self-documenting diff beats a body that paraphrases the diff.
@@ -224,6 +237,7 @@ caused timeouts.
 
 - [ ] Provides context NOT visible in the diff
 - [ ] Does NOT paraphrase comments, doc comments, or headers in the diff
+- [ ] Length is proportional to diff complexity (no padding)
 - [ ] Plaintext only (no Markdown)
 - [ ] Lines hard-wrapped at 72 characters
 - [ ] Paragraphs separated by blank lines

--- a/golang-dev/skills/committing/references/body-guidelines.md
+++ b/golang-dev/skills/committing/references/body-guidelines.md
@@ -17,6 +17,20 @@ Skip the body when:
 - Simple, straightforward changes with obvious motivation
 - Mechanical changes (tidy, formatting, renames)
 
+## Before Writing: The Stranger Test
+
+Before drafting any body, list the questions a stranger would still have after reading the diff with no other context. Write only the answers. If the list is empty, omit the body - a precise subject plus a self-documenting diff beats a body that paraphrases the diff.
+
+Useful prompts when generating the list:
+
+- Why now? What triggered this change?
+- What alternative was rejected, and why?
+- What does this unlock or unblock downstream?
+- What constraint, incident, or external decision forced this approach?
+- Where does this sit in a longer sequence of commits?
+
+Each answer earns its place in the body. Sentences that do not answer one of these questions usually duplicate the diff.
+
 ## Format Rules
 
 **Plaintext only** - NO Markdown formatting. Terminals don't render it.

--- a/golang-dev/skills/committing/references/body-guidelines.md
+++ b/golang-dev/skills/committing/references/body-guidelines.md
@@ -235,6 +235,8 @@ caused timeouts.
 
 ## Body Checklist
 
+Authoritative body validation. SKILL.md's summary references this list.
+
 - [ ] Provides context NOT visible in the diff
 - [ ] Does NOT paraphrase comments, doc comments, or headers in the diff
 - [ ] Length is proportional to diff complexity (no padding)

--- a/golang-dev/skills/committing/references/body-guidelines.md
+++ b/golang-dev/skills/committing/references/body-guidelines.md
@@ -31,6 +31,27 @@ Useful prompts when generating the list:
 
 Each answer earns its place in the body. Sentences that do not answer one of these questions usually duplicate the diff.
 
+### Worked Example: Stranger's Questions to Body
+
+Consider a diff that renames `parseSpec` to `parseSchema` across a parser package and updates every caller. A stranger reading the diff sees a clean find-and-replace and a passing test suite.
+
+What the diff cannot tell them:
+
+- Why now? The user-facing term changed from "spec" to "schema" in last week's API revision.
+- Why not keep both names with a type alias? The next commit introduces an unrelated `parseSpec` for module specifications; the names would collide.
+
+Write only those answers:
+
+```
+parser: rename parseSpec to parseSchema for API alignment
+
+Last week's API revision renamed the user-facing term from "spec"
+to "schema". An alias was considered but rejected because the next
+commit introduces an unrelated parseSpec for module specifications.
+```
+
+A typo fix in a doc comment leaves the stranger with no open questions; its body stays empty.
+
 ## Length Echoes Complexity
 
 A body's length should echo the diff's complexity. The body is not a place to demonstrate effort; it is a place to answer the questions the diff leaves open.

--- a/golang-dev/skills/committing/references/non-go-commits.md
+++ b/golang-dev/skills/committing/references/non-go-commits.md
@@ -83,6 +83,55 @@ github: label Dependabot PRs with "dependencies"
 github: enforce commit message format
 ```
 
+### Claude Code (`claude:`)
+
+Use `claude:` for Claude Code configuration and project memory.
+
+**Files:**
+- `CLAUDE.md` (project memory)
+- `.claude/` directory (settings.json, hooks, permissions)
+- `.claude-plugin/plugin.json` and other plugin manifests
+
+**Sentence completion:** "This change modifies Claude Code configuration to..."
+
+**Verbs:**
+- **document** - adds project memory or guidance
+- **configure** - general configuration
+- **allow** / **deny** - permission rules
+- **enable** / **disable** - feature toggles
+- **enforce** - enforces policies via hooks
+
+**Examples:**
+```
+claude: document repository navigation conventions
+claude: allow npm commands without prompts
+claude: enforce pre-commit linting via hook
+claude: enable plugin auto-discovery
+```
+
+### Agents (`agents:`)
+
+Use `agents:` for subagent definition files.
+
+**Files:**
+- `agents/*.md` (subagent definitions, in plugins or under `.claude/agents/`)
+
+**Sentence completion:** "This change modifies the agents to..."
+
+**Verbs:**
+- **define** - new agent
+- **specialize** - narrow agent scope
+- **expand** - widen triggers or capabilities
+- **delegate** - shift work to a specific agent
+- **retire** - drop an agent
+
+**Examples:**
+```
+agents: define plugin-validator for marketplace checks
+agents: specialize code-reviewer for security-sensitive paths
+agents: delegate test generation to go-test-writer
+```
+
 ### Git Configuration (`git:`)
 
 Use `git:` for Git configuration files.


### PR DESCRIPTION
The Go committing skill kept producing commit bodies that paraphrased the diff, spoke in the agent's voice, echoed the prompt back, or padded short changes with long bodies. Each was a different symptom of the same underlying gap: nothing in the skill named where the body sits relative to the diff and to the file's own comments.

This change introduces that mental model and the rules that flow from it. The body is now framed as WHY-EXTRINSIC - the surrounding story the diff cannot show - sitting alongside the diff (WHAT) and the file's own comments (WHY-INTRINSIC). On top of that frame the skill now forbids paraphrasing the diff (illustrated with a worked example), runs a stranger test before drafting any body, scales body length to diff complexity, requires the engineer's voice, and rejects any echo of user instructions. The body-guidelines reference is reordered so its sections mirror the writer's actual drafting sequence.

Along the way the skill also recognises Claude Code-related files via new ``claude:`` and ``agents:`` targets, and the frontmatter is modernised to use ``when_to_use`` and ``allowed-tools`` so trigger guidance is separated from the discovery description and read-only git inspection commands no longer prompt for permission on every diagnostic.

The plugin moves to 0.3.1 covering all of the above.

## Test plan
- [ ] Stage a diff whose own header comments document the change; verify the skill produces an outward-pointing body, not a paraphrase
- [ ] Stage a one-line typo fix; verify the skill omits the body
- [ ] Ask the skill to author a commit for an instruction-driven change; verify the body shows no agent voice or echoed prompt
- [ ] Stage a change under ``.claude/`` or in a ``CLAUDE.md`` and confirm the ``claude:`` target is selected
- [ ] Confirm the skill's ``git diff`` / ``git log`` / ``git status`` calls run without permission prompts