### PR TITLE
Teach commit-sequence planning ahead of message authoring

### DIFF
--- a/golang-dev/.claude-plugin/plugin.json
+++ b/golang-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "golang-dev",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Comprehensive Go development experience - skills that elevate Claude into the ultimate Golang developer",
   "author": {
     "name": "Daniel Orbach"

--- a/golang-dev/.claude-plugin/plugin.json
+++ b/golang-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "golang-dev",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Comprehensive Go development experience - skills that elevate Claude into the ultimate Golang developer",
   "author": {
     "name": "Daniel Orbach"

--- a/golang-dev/.claude-plugin/plugin.json
+++ b/golang-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "golang-dev",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Comprehensive Go development experience - skills that elevate Claude into the ultimate Golang developer",
   "author": {
     "name": "Daniel Orbach"

--- a/golang-dev/CHANGELOG.md
+++ b/golang-dev/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## planning-commits
 
+Encode per-commit hygiene as part of the incremental facet.
+
+- Extend `references/triad.md` so the incremental facet names mechanical hygiene — formatting, tidying, regenerating derived files — as belonging within each commit, never deferred to a trailing dump
+- Surface the same rule in SKILL.md workflow step 3 so it applies whether or not the triad reference has been loaded
+- Add `examples/go-mod-get-before-use.md` showing one `go.mod: get` commit per module ahead of the first caller, with `go mod tidy` run before staging
+- Add `examples/go-mod-tidy-first.md` showing how to detect a contaminated working tree and isolate its cleanup as the first commit
+- Add `examples/antipattern-trailing-format-dump.md` covering the format/tidy analogue of the trailing-docs-dump anti-pattern, with framing that defers to per-repo tooling awareness rather than hardcoding a specific stack
+
 Polish pass following initial-release review.
 
 - Tighten SKILL.md description by removing the sibling-skill example, leaving the body to name the message-writing hand-off

--- a/golang-dev/CHANGELOG.md
+++ b/golang-dev/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## planning-commits
+
+Initial release of the planning-commits skill for sequencing atomic, fine-grained, incremental commits before any code is written or messages are drafted.
+
+- Core workflow inspecting the changeset, identifying capabilities and decisions, drafting the plan, presenting for approval, and handing each commit off to a message-writing skill
+- Triad reference defining atomic, fine-grained, and incremental with the value-vs-syntactic distinction and the decision-rationale-layering benefit
+- Plan-shape reference specifying the single-sentence scope plus context paragraph deliverable and the hand-off contract to commit-message-writing skills
+- Six positive examples covering skeleton-first introductions, flags growing with their features, siblings split by decision context, docs travelling with their feature, isolated dependency adoption, and decision-rationale layering
+- Five anti-pattern examples covering syntactic grouping by symbol kind, abstraction layer, and mechanical role, plus the flags-up-front and trailing docs-dump failures
+- Language-agnostic triggers covering "plan commits", "break this into commits", "atomic commits", and proactive loading before any non-trivial changeset
+- Validation checklist and special-case guidance for mixed-language, dependency-only, and large-refactor changesets
+
 ## naming
 
 Initial release of the naming skill for Go identifiers.
@@ -12,6 +24,10 @@ Initial release of the naming skill for Go identifiers.
 - Comprehensive coverage of Go team conventions including MixedCaps, initialisms, and repetition avoidance
 
 ## committing
+
+Defer commit-splitting decisions to the new planning-commits skill.
+
+- Replace the "consider splitting into separate commits" guidance in Mixed Changes with a pointer to `golang-dev:planning-commits`
 
 Modernize skill frontmatter to use current Claude Code fields.
 

--- a/golang-dev/CHANGELOG.md
+++ b/golang-dev/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## planning-commits
 
+Polish pass following initial-release review.
+
+- Tighten SKILL.md description by removing the sibling-skill example, leaving the body to name the message-writing hand-off
+- Collapse the inline anti-pattern enumeration in Workflow step 2 to a pointer at the Example Files table
+- Surface the "premature naming" guardrail from plan-shape into Workflow step 3 so it lands without loading the reference
+- Generalise the manifest-tidying example to name Go, npm, and Cargo ecosystems
+- Correct a possessive typo in docs-with-feature.md
+
 Initial release of the planning-commits skill for sequencing atomic, fine-grained, incremental commits before any code is written or messages are drafted.
 
 - Core workflow inspecting the changeset, identifying capabilities and decisions, drafting the plan, presenting for approval, and handing each commit off to a message-writing skill

--- a/golang-dev/skills/committing/SKILL.md
+++ b/golang-dev/skills/committing/SKILL.md
@@ -222,7 +222,7 @@ Each example file documents its XML tag conventions at the top.
 
 When changes span both Go code and non-Go files:
 
-1. Consider splitting into separate commits (preferred)
+1. Plan the split first using `golang-dev:planning-commits`, then return to this skill for each commit's message
 2. If logically unified, choose the PRIMARY functional impact as target
 3. Use `all:` only for truly cross-cutting refactoring
 

--- a/golang-dev/skills/planning-commits/SKILL.md
+++ b/golang-dev/skills/planning-commits/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: planning-commits
+description: Plans a fine-grained sequence of atomic, incremental commits for a non-trivial changeset before any code is written or any commit message is drafted. Language-agnostic; defers message-writing to a separate skill (such as `golang-dev:committing` for Go-centric repos).
+when_to_use: Triggers on explicit user requests like "plan commits", "break this into commits", "how should I split this", "commit incrementally", "atomic commits", "fine-grained commits", or scoldings such as "DON'T commit all X at once". Loads proactively at the EARLIEST signal that a non-trivial changeset is forming, regardless of language: when starting work expected to produce more than one capability, when changes have already accumulated across unrelated concerns, or when about to enter a write-and-commit loop on work spanning multiple files or decisions. Triggers ahead of any commit-message-writing skill — the plan is the input those skills consume. Do not wait for the word "commit" to appear in user prose; in any non-trivial task, commits are inevitable and the sequence is best chosen before the first line of code lands.
+allowed-tools: Bash(git diff:*) Bash(git log:*) Bash(git status:*)
+---
+
+# Planning Commits
+
+Plan the sequence of commits for any non-trivial changeset before writing code, and before drafting commit messages. The skill's output is a plan: a numbered list where each entry states one commit's scope in a single sentence and the context that motivates it.
+
+Commit-message-writing skills consume this plan one entry at a time. Defer all message phrasing to the appropriate writing skill — in a Go-centric repository, `golang-dev:committing`. Planning stops at scope and context; naming the commit is a separate concern handled later.

--- a/golang-dev/skills/planning-commits/SKILL.md
+++ b/golang-dev/skills/planning-commits/SKILL.md
@@ -48,3 +48,71 @@ Some changesets do not warrant a plan:
 - **Single-capability changesets.** When the entire diff is the smallest version of one reviewable change, the plan has one entry — which is to say there is nothing to plan. Hand off to the message-writing skill directly.
 
 When skipping, do not ask. Proceed to writing directly and let the user redirect if they want a plan after all.
+
+## Workflow
+
+When planning commits for a non-trivial changeset:
+
+### 1. Inspect the Working Tree
+
+```bash
+git status
+git diff
+```
+
+Identify what has changed and what remains to be changed. If the work has not started, inspect the brief itself — what the user described, which files will likely change.
+
+### 2. Identify Capabilities and Decisions
+
+Read the changeset or brief for distinct units of value:
+
+- User-facing capabilities (endpoints, commands, public APIs, features).
+- Single decisions worth isolating (dependency choices, policy switches, architectural commitments).
+- Documentation that travels with each capability.
+
+If the first instinct is to group by symbol kind, abstraction layer, or mechanical role, stop. Consult `examples/antipattern-by-symbol-kind.md`, `examples/antipattern-by-layer.md`, or `examples/antipattern-by-mechanical-layer.md` to recognise the failure mode.
+
+### 3. Draft the Plan
+
+Produce a numbered list in the shape defined by `references/plan-shape.md`. For each entry:
+
+- A single sentence stating the scope.
+- A paragraph stating the context: why this commit, why now, what it deliberately does not include.
+
+Start with a skeleton commit when the work introduces a new package, module, or subsystem (see `examples/skeleton-first.md`). Layer capabilities one per commit, each carrying the docs, flags, and tests it justifies.
+
+### 4. Present for Approval
+
+Show the plan to the user. Make it easy to redirect:
+
+- Number each entry so the user can reference individual commits.
+- Keep entries brief enough that the whole plan fits in one screen.
+- Invite specific corrections rather than open-ended feedback.
+
+The plan is a proposal, not a contract. Adjust it freely as the user redirects.
+
+### 5. Hand Off Each Commit to the Message-Writing Skill
+
+When implementing a commit from the plan:
+
+1. Stage only the changes for that entry's scope.
+2. Load the commit-message-writing skill appropriate to the repository — in a Go-centric repository, `golang-dev:committing`.
+3. Pass the entry's scope and context as input to that skill, which produces the actual commit message.
+
+The plan entry is the input; the commit message is the output of the message-writing skill, not of this one.
+
+## Example Files
+
+| File | Pattern | Demonstrates |
+|------|---------|--------------|
+| `examples/skeleton-first.md` | First commit lays the ground | Incremental |
+| `examples/flags-grow-with-features.md` | Flags arrive with their feature | Atomic |
+| `examples/siblings-by-decision.md` | Sibling endpoints split by contract | Atomic |
+| `examples/docs-with-feature.md` | Docs travel with their feature | Incremental |
+| `examples/dependency-adoption-isolated.md` | Dependency choice gets its own commit | Atomic (decision layering) |
+| `examples/decision-rationale-layering.md` | Decision body carries WHY-EXTRINSIC | Atomic (decision layering) |
+| `examples/antipattern-by-symbol-kind.md` | All types, then all methods | Counter-example |
+| `examples/antipattern-by-layer.md` | Interfaces, then implementations | Counter-example |
+| `examples/antipattern-by-mechanical-layer.md` | All handlers, then routes, then tests | Counter-example |
+| `examples/antipattern-flags-up-front.md` | All flags at the start | Counter-example |
+| `examples/antipattern-trailing-docs-dump.md` | Docs piled into a final commit | Counter-example |

--- a/golang-dev/skills/planning-commits/SKILL.md
+++ b/golang-dev/skills/planning-commits/SKILL.md
@@ -116,3 +116,48 @@ The plan entry is the input; the commit message is the output of the message-wri
 | `examples/antipattern-by-mechanical-layer.md` | All handlers, then routes, then tests | Counter-example |
 | `examples/antipattern-flags-up-front.md` | All flags at the start | Counter-example |
 | `examples/antipattern-trailing-docs-dump.md` | Docs piled into a final commit | Counter-example |
+
+## Validation Checklist
+
+Before presenting the plan:
+
+**Each entry:**
+- [ ] Scope is a single sentence (not a properly-formed commit message)
+- [ ] Context is a paragraph stating why this commit, why now, and what it deliberately excludes
+- [ ] The commit's changes can be reverted in isolation without breaking subsequent commits' premises
+- [ ] No forward reference to a symbol, behaviour, or file that no later commit introduces
+
+**Across the sequence:**
+- [ ] First commit is a skeleton or the smallest-standalone value, never a forward-referencing stub
+- [ ] Flags arrive with the features that consume them, not up front
+- [ ] Docs travel with each feature commit, never piled into a trailing dump
+- [ ] No commit groups by symbol kind, abstraction layer, or mechanical role
+- [ ] Decisions worth defending later have their own commit with body-carryable rationale
+
+**Overall:**
+- [ ] A reviewer can evaluate each commit in isolation and form an opinion
+- [ ] Reverting any single commit leaves the branch in a coherent state
+- [ ] The sequence builds the final value, not just a rearrangement of files
+
+## Special Cases
+
+### Mixed-Language Changesets
+
+When a changeset spans multiple languages or ecosystems (a Go service plus its Helm chart, a Rust library plus its Python bindings):
+
+- Plan each capability's full vertical stack as one commit, not each language's contribution as a separate commit.
+- The exception is when the cross-language wiring itself is the decision worth isolating. A binding-generator switch, for example, is a decision commit even if the diff spans both languages.
+
+### Dependency-Only Changes
+
+When the entire changeset is `go.mod`/`package.json`/`Cargo.toml` updates with no new callers and no behavioural changes:
+
+- Group by what kinds of dependencies are updated and why. A security-patch sweep is one commit; unrelated minor-version bumps are separate commits.
+- If a major-version update forces code changes, that is a decision commit (see `examples/decision-rationale-layering.md`).
+
+### Large Refactors
+
+When a refactor crosses many files but introduces no new capabilities:
+
+- Plan by the conceptual transformation, not by file. "Rename Foo to Bar across the codebase" is one commit if the rename is purely mechanical. "Restructure error returns to expose typed errors" is several commits, one per call-site cluster that shares an error contract.
+- Mechanical commits and decision commits should not mix. If the refactor exposes a decision worth defending (e.g., choosing a specific error taxonomy), that decision lands in its own commit with the rationale.

--- a/golang-dev/skills/planning-commits/SKILL.md
+++ b/golang-dev/skills/planning-commits/SKILL.md
@@ -70,7 +70,7 @@ Read the changeset or brief for distinct units of value:
 - Single decisions worth isolating (dependency choices, policy switches, architectural commitments).
 - Documentation that travels with each capability.
 
-If the first instinct is to group by symbol kind, abstraction layer, or mechanical role, stop. Consult `examples/antipattern-by-symbol-kind.md`, `examples/antipattern-by-layer.md`, or `examples/antipattern-by-mechanical-layer.md` to recognise the failure mode.
+If the first instinct is to group by symbol kind, abstraction layer, or mechanical role, stop. Consult the anti-pattern examples in the table below to recognise the failure mode before drafting the plan.
 
 ### 3. Draft the Plan
 

--- a/golang-dev/skills/planning-commits/SKILL.md
+++ b/golang-dev/skills/planning-commits/SKILL.md
@@ -81,6 +81,8 @@ Produce a numbered list in the shape defined by `references/plan-shape.md`. For 
 
 Start with a skeleton commit when the work introduces a new package, module, or subsystem (see `examples/skeleton-first.md`). Layer capabilities one per commit, each carrying the docs, flags, and tests it justifies.
 
+Each commit's diff stays scoped to its own change, including the mechanical hygiene (formatting, manifest tidying, regenerating derived files) the change itself produces. When the working tree starts contaminated before work begins, the cleanup belongs in a dedicated first commit, not buried in the first feature commit.
+
 A plan entry that reads like a good commit message is a sign of premature naming — strip it back to plain prose before continuing. The message-writing skill in step 5 produces the actual phrasing.
 
 ### 4. Present for Approval
@@ -113,11 +115,14 @@ The plan entry is the input; the commit message is the output of the message-wri
 | `examples/docs-with-feature.md` | Docs travel with their feature | Incremental |
 | `examples/dependency-adoption-isolated.md` | Dependency choice gets its own commit | Atomic (decision layering) |
 | `examples/decision-rationale-layering.md` | Decision body carries WHY-EXTRINSIC | Atomic (decision layering) |
+| `examples/go-mod-get-before-use.md` | One `go.mod: get` per module, ahead of use | Atomic (Go-specialised) |
+| `examples/go-mod-tidy-first.md` | Cleanup of a contaminated tree as the first commit | Atomic / Incremental |
 | `examples/antipattern-by-symbol-kind.md` | All types, then all methods | Counter-example |
 | `examples/antipattern-by-layer.md` | Interfaces, then implementations | Counter-example |
 | `examples/antipattern-by-mechanical-layer.md` | All handlers, then routes, then tests | Counter-example |
 | `examples/antipattern-flags-up-front.md` | All flags at the start | Counter-example |
 | `examples/antipattern-trailing-docs-dump.md` | Docs piled into a final commit | Counter-example |
+| `examples/antipattern-trailing-format-dump.md` | Formatting and tidying deferred to a trailing commit | Counter-example |
 
 ## Validation Checklist
 

--- a/golang-dev/skills/planning-commits/SKILL.md
+++ b/golang-dev/skills/planning-commits/SKILL.md
@@ -10,3 +10,20 @@ allowed-tools: Bash(git diff:*) Bash(git log:*) Bash(git status:*)
 Plan the sequence of commits for any non-trivial changeset before writing code, and before drafting commit messages. The skill's output is a plan: a numbered list where each entry states one commit's scope in a single sentence and the context that motivates it.
 
 Commit-message-writing skills consume this plan one entry at a time. Defer all message phrasing to the appropriate writing skill — in a Go-centric repository, `golang-dev:committing`. Planning stops at scope and context; naming the commit is a separate concern handled later.
+
+## Core Principles
+
+A commit plan satisfies three facets together — atomic, fine-grained, incremental:
+
+- **Atomic.** Group changes by value (user-facing capability, feature, single decision), not by syntactic category (all types, all interfaces, all handlers). Each commit advances one identifiable piece of value that can be reverted, evaluated, or rebased in isolation from its neighbours.
+- **Fine-grained.** Each commit lands one reviewable change. The test is reviewability, not file count: a two-line diff can be fine-grained, a fifty-file diff is not, regardless of how small each edit is.
+- **Incremental.** Build the final value over a planned sequence. Start with a skeleton; layer capabilities; never forward-reference symbols or behaviours that do not yet exist on the branch.
+
+For the full definitions, including the value-vs-syntactic distinction and the decision-rationale-layering benefit, consult `references/triad.md`.
+
+## Reference Files
+
+| File | Contains | Load When |
+|------|----------|-----------|
+| `references/triad.md` | Full definitions of atomic, fine-grained, incremental, with the value-vs-syntactic distinction | First time the skill triggers in a session |
+| `references/plan-shape.md` | Shape of a plan entry, hand-off to the message-writing skill, worked mini-example | Before producing the plan deliverable |

--- a/golang-dev/skills/planning-commits/SKILL.md
+++ b/golang-dev/skills/planning-commits/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: planning-commits
-description: Plans a fine-grained sequence of atomic, incremental commits for a non-trivial changeset before any code is written or any commit message is drafted. Language-agnostic; defers message-writing to a separate skill (such as `golang-dev:committing` for Go-centric repos).
+description: Plans a fine-grained sequence of atomic, incremental commits for a non-trivial changeset before any code is written or any commit message is drafted. Language-agnostic; defers commit-message authoring to a separate skill.
 when_to_use: Triggers on explicit user requests like "plan commits", "break this into commits", "how should I split this", "commit incrementally", "atomic commits", "fine-grained commits", or scoldings such as "DON'T commit all X at once". Loads proactively at the EARLIEST signal that a non-trivial changeset is forming, regardless of language: when starting work expected to produce more than one capability, when changes have already accumulated across unrelated concerns, or when about to enter a write-and-commit loop on work spanning multiple files or decisions. Triggers ahead of any commit-message-writing skill — the plan is the input those skills consume. Do not wait for the word "commit" to appear in user prose; in any non-trivial task, commits are inevitable and the sequence is best chosen before the first line of code lands.
 allowed-tools: Bash(git diff:*) Bash(git log:*) Bash(git status:*)
 ---

--- a/golang-dev/skills/planning-commits/SKILL.md
+++ b/golang-dev/skills/planning-commits/SKILL.md
@@ -43,7 +43,7 @@ Do not wait for the word "commit" to appear in user prose. In any non-trivial ta
 
 Some changesets do not warrant a plan:
 
-- **Mechanical edits.** Typo fixes, formatting passes, dependency-only `go.mod tidy`, single-line bug fixes. The plan would have one entry; producing it is overhead.
+- **Mechanical edits.** Typo fixes, formatting passes, dependency-manifest tidying (`go mod tidy`, `npm prune`, `cargo update --workspace`), single-line bug fixes. The plan would have one entry; producing it is overhead.
 - **Exploratory work.** The user has signalled they are "playing around" or "just trying something" and no commits are planned for this session. Wait for the user to convert exploration into intent before planning.
 - **Single-capability changesets.** When the entire diff is the smallest version of one reviewable change, the plan has one entry — which is to say there is nothing to plan. Hand off to the message-writing skill directly.
 

--- a/golang-dev/skills/planning-commits/SKILL.md
+++ b/golang-dev/skills/planning-commits/SKILL.md
@@ -27,3 +27,24 @@ For the full definitions, including the value-vs-syntactic distinction and the d
 |------|----------|-----------|
 | `references/triad.md` | Full definitions of atomic, fine-grained, incremental, with the value-vs-syntactic distinction | First time the skill triggers in a session |
 | `references/plan-shape.md` | Shape of a plan entry, hand-off to the message-writing skill, worked mini-example | Before producing the plan deliverable |
+
+## When to Plan
+
+Plan commits proactively at the earliest signal that the work ahead is non-trivial:
+
+- A user brief mentions more than one capability, feature, or decision.
+- The working tree already contains unstaged changes spanning unrelated concerns.
+- The expected diff is larger than what a reviewer can hold in their head as one decision.
+- A user has scolded about commit shape, granularity, or sequence in a prior turn.
+
+Do not wait for the word "commit" to appear in user prose. In any non-trivial task, commits are inevitable and the sequence is best chosen before the first line of code lands.
+
+## When to Skip Planning
+
+Some changesets do not warrant a plan:
+
+- **Mechanical edits.** Typo fixes, formatting passes, dependency-only `go.mod tidy`, single-line bug fixes. The plan would have one entry; producing it is overhead.
+- **Exploratory work.** The user has signalled they are "playing around" or "just trying something" and no commits are planned for this session. Wait for the user to convert exploration into intent before planning.
+- **Single-capability changesets.** When the entire diff is the smallest version of one reviewable change, the plan has one entry — which is to say there is nothing to plan. Hand off to the message-writing skill directly.
+
+When skipping, do not ask. Proceed to writing directly and let the user redirect if they want a plan after all.

--- a/golang-dev/skills/planning-commits/SKILL.md
+++ b/golang-dev/skills/planning-commits/SKILL.md
@@ -81,6 +81,8 @@ Produce a numbered list in the shape defined by `references/plan-shape.md`. For 
 
 Start with a skeleton commit when the work introduces a new package, module, or subsystem (see `examples/skeleton-first.md`). Layer capabilities one per commit, each carrying the docs, flags, and tests it justifies.
 
+A plan entry that reads like a good commit message is a sign of premature naming — strip it back to plain prose before continuing. The message-writing skill in step 5 produces the actual phrasing.
+
 ### 4. Present for Approval
 
 Show the plan to the user. Make it easy to redirect:

--- a/golang-dev/skills/planning-commits/examples/antipattern-by-layer.md
+++ b/golang-dev/skills/planning-commits/examples/antipattern-by-layer.md
@@ -1,0 +1,53 @@
+# Anti-pattern: grouping by abstraction layer
+
+The temptation arises when a feature introduces an interface and its implementations together. The agent thinks: "Let me first define all the contracts, then fill in the implementations." Sounds disciplined — and produces commits nobody can review.
+
+## The anti-pattern
+
+A feature that introduces pluggable storage backends gets split as:
+
+```
+1. Define the Storage interface and its method contracts
+   Land the Storage interface with Get, Put, Delete, List, and the
+   accompanying Result and Error types. No implementations land in
+   this commit.
+
+2. Implement the InMemoryStorage backend
+   Land the in-memory implementation that satisfies the Storage
+   interface from commit 1.
+
+3. Implement the SQLiteStorage backend
+   Land the SQLite-backed implementation that satisfies the same
+   interface.
+```
+
+## Why this is wrong
+
+Violates the atomic facet, and pressures the incremental one:
+
+- **Atomic.** Commit 1's interface delivers no value on its own. A reviewer cannot evaluate whether the contract is right because no implementation has tested it against real constraints and no caller exercises it. The shape of an interface is best judged by its first consumer.
+- **Incremental.** The interface as drafted in commit 1 will almost certainly need revision once the first real implementation runs into a constraint that was not anticipated. Locking it in before any implementation exists forces either a follow-up "amend the interface" commit (noise) or implementations bent to fit an awkward contract.
+
+The split is syntactic — by abstraction layer in the design. The value, a working storage backend with an interface that proves itself, is fractured across commits whose ordering enforces unhelpful constraints.
+
+## Better
+
+Pair each implementation with the interface shape it justifies:
+
+```
+1. Land InMemoryStorage with the Storage interface it satisfies
+   The interface emerges from a concrete implementation that has
+   at least one real caller. Get, Put, Delete, and List are
+   defined as the minimum set the in-memory backend needs to be
+   useful for testing. A reviewer evaluates the interface against
+   a working thing, not against speculation.
+
+2. Land SQLiteStorage and refine the Storage interface where needed
+   Adding a persistent backend forces decisions the in-memory case
+   did not: connection management, transactional semantics,
+   pagination shape for List. If the interface needs new methods
+   or refined signatures, that revision lands here, justified by
+   the SQLite implementation that demands it.
+```
+
+The interface still exists across both commits — but its shape is grounded in a working implementation at every step, not in upfront speculation.

--- a/golang-dev/skills/planning-commits/examples/antipattern-by-mechanical-layer.md
+++ b/golang-dev/skills/planning-commits/examples/antipattern-by-mechanical-layer.md
@@ -1,0 +1,57 @@
+# Anti-pattern: grouping by mechanical role
+
+The temptation arises when a feature spans multiple files of the same mechanical role: handlers, routes, services, repositories, tests, migrations. The agent's instinct is to group commits by role because "that's how the directory structure is organised."
+
+## The anti-pattern
+
+A feature that adds three new HTTP endpoints to a service gets split as:
+
+```
+1. Add the three new handlers
+   Land internal/handlers/{create,list,delete}_order.go all
+   together because they are "the handlers this feature
+   introduces."
+
+2. Wire the three new routes
+   Land the route registrations for the three new endpoints in
+   internal/router/router.go because they are "the routes this
+   feature introduces."
+
+3. Add tests for the three new endpoints
+   Land internal/handlers/{create,list,delete}_order_test.go all
+   together because they are "the tests this feature introduces."
+```
+
+## Why this is wrong
+
+Violates the atomic facet. None of these commits stands alone as a unit of value:
+
+- Commit 1 is three handler files that no router will reach. The reviewer cannot trace request → handler → response because the routes do not yet exist.
+- Commit 2 wires routes to handlers that already exist but cannot be tested because the test files do not land until commit 3.
+- Commit 3 lands tests for code that has been live and routable for two commits already, leaving no checkpoint between regressions that slipped in earlier.
+
+The split is syntactic — by file directory or mechanical role. Each endpoint's full story (handler + route + test) is spread across all three commits, and bisecting a regression requires reading all three.
+
+## Better
+
+Split by user-facing capability — each endpoint in its own commit, carrying its handler, route, and tests together:
+
+```
+1. Expose POST /orders to create new orders
+   Land the create handler, its route registration, and its tests
+   in one commit. A reviewer evaluates the entire capability in
+   one place: request shape, validation, persistence, response
+   format, error semantics.
+
+2. Expose GET /orders to list orders for the authenticated user
+   Same shape: handler, route, tests, in one commit. Authorization
+   semantics — what "authenticated user" means here, and how the
+   query is scoped — land in this commit because they are part of
+   the capability.
+
+3. Expose DELETE /orders/{id} to remove an order
+   Same shape. The soft-delete-vs-hard-delete decision lands here
+   because it is part of this capability's contract.
+```
+
+Each commit is independently revertable, evaluable, and bisectable. A regression report mentioning DELETE /orders points at one commit.

--- a/golang-dev/skills/planning-commits/examples/antipattern-by-symbol-kind.md
+++ b/golang-dev/skills/planning-commits/examples/antipattern-by-symbol-kind.md
@@ -1,0 +1,57 @@
+# Anti-pattern: grouping by symbol kind
+
+The temptation arises when a feature introduces many declarations of similar shape. An agent — especially an LLM working from a high-level brief — looks at the diff, sees "types here, methods there, functions over yonder" and proposes a "tidy" split along those lines.
+
+## The anti-pattern
+
+A feature that adds a streaming JSON parser to an existing `json` package gets split as:
+
+```
+1. Add the new Decoder, TokenReader, and Stream types
+   Land all three new type declarations together because they are
+   "the types this feature introduces."
+
+2. Add the methods on Decoder, TokenReader, and Stream
+   Land Decoder.Decode, TokenReader.Next, Stream.Reset, and so on,
+   all together because they are "the methods this feature
+   introduces."
+
+3. Add the package-level constructors and helpers
+   Land NewDecoder, NewTokenReader, parseValue, and any private
+   helpers because they are "the functions this feature
+   introduces."
+```
+
+## Why this is wrong
+
+Violates the atomic facet. None of these commits stands alone as a unit of value:
+
+- Commit 1 lands three types nobody can call into; a reviewer cannot evaluate whether the shape is right because there is no behaviour to read.
+- Commit 2 lands a wall of methods whose intent is impossible to assess without flipping back to commit 1 for the type they hang off and forward to commit 3 for the constructor that creates them.
+- Commit 3 lands constructors and helpers whose purpose is buried in the previous two commits.
+
+The split is **syntactic** — by category in the language's grammar. The value it delivers, a working streaming parser, is fractured across three commits, none of which is independently revertable, reviewable, or rebaseable.
+
+## Better
+
+Split by value, not by symbol kind:
+
+```
+1. Land Decoder with its construction, Decode method, and tests
+   Decoder is the smallest standalone value: parse a JSON document
+   from an io.Reader and return a Go value. Type declaration,
+   methods, constructor, and table-driven tests for this slice all
+   land together.
+
+2. Land TokenReader with its Next/Read methods and tests
+   TokenReader adds the streaming-token surface. Same shape as
+   commit 1, but the value is the lower-level token API. Type,
+   methods, constructor, and tests for this slice land together.
+
+3. Land Stream with its reset semantics and concurrent-use tests
+   Stream is the long-lived reusable variant. Its value is
+   allocation reuse across multiple parses. Type, methods, and the
+   tests that exercise reset land together.
+```
+
+Each commit lands a coherent slice of value. A reviewer evaluating commit 2 sees the entire TokenReader story — type, methods, constructor, tests — in one place.

--- a/golang-dev/skills/planning-commits/examples/antipattern-flags-up-front.md
+++ b/golang-dev/skills/planning-commits/examples/antipattern-flags-up-front.md
@@ -1,0 +1,38 @@
+# Anti-pattern: flags landed up front
+
+The temptation arises when an agent reads a feature brief, anticipates several flags the work will eventually need, and lands them all at the start "so the wiring is ready". This is one of the most consistent failure modes for LLM agents working from a brief.
+
+## The anti-pattern
+
+A multi-step build-out of an HTTP server gets split as:
+
+```
+1. Land all the configuration flags
+   Register --addr, --timeout, --rate-limit, --health-timeout,
+   --metrics-port, and --tls-cert in main.go. Each flag has a
+   default and a help string. No features that consume any of
+   these flags exist yet.
+
+2. Wire the listener using --addr
+   Read the previously-introduced --addr flag and bind the
+   listener.
+
+3. Add the /healthz endpoint using --health-timeout
+   Implement the readiness check, consuming the --health-timeout
+   flag introduced two commits ago.
+
+[...]
+```
+
+## Why this is wrong
+
+Violates both the atomic and incremental facets:
+
+- **Atomic.** Commit 1 lands six flags none of which have a feature behind them. Each flag's default, name, and help string is undefended by any test or use site. A reviewer evaluating commit 1 has nothing to evaluate against.
+- **Incremental.** Commits 3 and onward each consume a flag introduced by an earlier commit, which is a forward reference in reverse: the flag was a forward reference to the feature when it landed. By the time the feature arrives, the flag's name and default may no longer fit — but they are now "established" and resist revision.
+
+The user guidance behind this pattern is emphatic: never commit all flags at once. Flags are extended across commits as more features are added requiring more flags.
+
+## Better
+
+See `examples/flags-grow-with-features.md` for the correct shape: each flag lands in the same commit as the feature that consumes it, with a default justified by the feature's observable behaviour.

--- a/golang-dev/skills/planning-commits/examples/antipattern-trailing-docs-dump.md
+++ b/golang-dev/skills/planning-commits/examples/antipattern-trailing-docs-dump.md
@@ -1,0 +1,36 @@
+# Anti-pattern: trailing docs dump
+
+The temptation arises near the end of a feature series. The agent has shipped the code, written tests, fixed regressions — and "still has to update the docs." The natural-feeling move is to bundle all the doc updates into a single trailing commit.
+
+## The anti-pattern
+
+A feature series that adds three new APIs ends as:
+
+```
+1. Land Encoder
+2. Land Decoder
+3. Land streaming variants
+4. Update README, package doc, and examples
+   Add the README sections describing Encoder, Decoder, and the
+   streaming variants. Update the package doc to mention the new
+   types. Add example_test.go entries for all three.
+```
+
+## Why this is wrong
+
+Violates the incremental facet:
+
+- For three consecutive commits the public API has existed in a state the documentation does not describe. Anyone running `go doc`, reading the README, or scanning examples sees a stale picture.
+- A reader of `git blame` on the README's Encoder section lands on commit 4 — a commit whose primary subject is "docs update" — rather than on commit 1 where the encoder was introduced and the rationale for its shape lived.
+- Commit 4 itself is hard to review. Three features-worth of documentation in one diff forces the reviewer to context-switch across all three features simultaneously, in a commit whose stated purpose offers no scaffolding for that context.
+
+## Better
+
+Docs travel with their feature. See `examples/docs-with-feature.md` for the positive shape — each feature commit also lands the documentation that describes it, and the README is built non-linearly as the narrative requires.
+
+## Why this anti-pattern is sticky
+
+The trailing docs dump is rationalised as "I'll write better docs once I see the whole feature working." This sounds disciplined but produces worse docs in two ways:
+
+- The rationale for design choices is freshest at the moment the choice is made. Writing the docs three commits later loses that freshness — the writer has to reconstruct the reasoning and often defaults to describing what the code does rather than why.
+- Docs reviewed in their own commit get less scrutiny than docs reviewed alongside the code they describe. The reviewer who saw "Encoder lands here" in commit 1 would have caught a misleading README sentence in that same commit; in commit 4, they skim.

--- a/golang-dev/skills/planning-commits/examples/antipattern-trailing-format-dump.md
+++ b/golang-dev/skills/planning-commits/examples/antipattern-trailing-format-dump.md
@@ -1,6 +1,6 @@
 # Anti-pattern: trailing format or tidy dump
 
-The temptation arises at the end of a feature series. The agent has shipped the code, made it work, and is "about to clean up". The natural-feeling move is to run `gofmt`, `go mod tidy`, the lint auto-fixer, and any code generator once at the end, bundling the result into a single trailing tidy commit.
+The temptation arises at the end of a feature series. The agent has shipped the code, made it work, and is "about to clean up". The natural-feeling move is to run all the project's formatters, manifest tidiers, and auto-fixers once at the end, bundling the result into a single trailing tidy commit.
 
 ## The anti-pattern
 
@@ -20,16 +20,16 @@ A feature series ends as:
 
 Violates the atomic facet on two axes:
 
-- **CI is broken between intermediate commits.** For three consecutive commits, the source tree fails `gofmt -l .` and `go mod tidy && git diff --exit-code`. Any CI step or bisect run against commits 1, 2, or 3 sees failures that have nothing to do with that commit's actual change.
+- **CI is broken between intermediate commits.** For three consecutive commits, the source tree fails whichever format-and-tidy checks the project enforces. Any CI step or bisect run against commits 1, 2, or 3 sees failures that have nothing to do with that commit's actual change.
 - **The trailing commit is a dumping ground.** Commit 4's diff mixes mechanical edits across files from three different feature commits. Bisecting a regression that landed in commit 2 has to read through commit 4's noise to see the change in its original context. Worse, the "tidy" commit accretes whatever auto-fixes the tooling can find, so it ends up doing several unrelated cleanups under one label.
 
 ## Better
 
 Every commit cleans up after itself:
 
-- Commit 1's diff is `gofmt`-clean; if it added a module, `go mod tidy` was run before staging.
-- Commit 2's diff is `gofmt`-clean; same hygiene contract.
-- Commit 3's diff is `gofmt`-clean.
+- Commit 1's diff passes the project's format and tidy checks; if it added a dependency, the manifest was tidied before staging.
+- Commit 2 holds the same hygiene contract.
+- Commit 3 holds the same hygiene contract.
 
 No trailing commit is needed because no debt was accumulated.
 

--- a/golang-dev/skills/planning-commits/examples/antipattern-trailing-format-dump.md
+++ b/golang-dev/skills/planning-commits/examples/antipattern-trailing-format-dump.md
@@ -1,0 +1,46 @@
+# Anti-pattern: trailing format or tidy dump
+
+The temptation arises at the end of a feature series. The agent has shipped the code, made it work, and is "about to clean up". The natural-feeling move is to run `gofmt`, `go mod tidy`, the lint auto-fixer, and any code generator once at the end, bundling the result into a single trailing tidy commit.
+
+## The anti-pattern
+
+A feature series ends as:
+
+```
+1. Add the new Encoder type
+2. Add the streaming Decoder
+3. Wire both into the public API
+4. Run go mod tidy, gofmt, and lint auto-fixes
+   Apply the formatter to all files touched in the series, then
+   `go mod tidy` to remove any unused entries, then `golangci-lint
+   run --fix`. The diff spans files from commits 1, 2, and 3.
+```
+
+## Why this is wrong
+
+Violates the atomic facet on two axes:
+
+- **CI is broken between intermediate commits.** For three consecutive commits, the source tree fails `gofmt -l .` and `go mod tidy && git diff --exit-code`. Any CI step or bisect run against commits 1, 2, or 3 sees failures that have nothing to do with that commit's actual change.
+- **The trailing commit is a dumping ground.** Commit 4's diff mixes mechanical edits across files from three different feature commits. Bisecting a regression that landed in commit 2 has to read through commit 4's noise to see the change in its original context. Worse, the "tidy" commit accretes whatever auto-fixes the tooling can find, so it ends up doing several unrelated cleanups under one label.
+
+## Better
+
+Every commit cleans up after itself:
+
+- Commit 1's diff is `gofmt`-clean; if it added a module, `go mod tidy` was run before staging.
+- Commit 2's diff is `gofmt`-clean; same hygiene contract.
+- Commit 3's diff is `gofmt`-clean.
+
+No trailing commit is needed because no debt was accumulated.
+
+If the working tree starts contaminated — drift from an earlier branch, leftover entries from a reverted spike — see `examples/go-mod-tidy-first.md` for the right shape: a single cleanup commit at the head of the series, with no feature work mixed in. After that one-time cleanup, every subsequent commit holds the line.
+
+## Why this anti-pattern is sticky
+
+The trailing tidy is rationalised as "I will format once at the end so I do not waste effort formatting code I might still rewrite." The cost-benefit changes once the work is reviewed:
+
+- Reviewers running CI locally against any intermediate commit see breakage.
+- Bisects across the series cross a noisy commit that did not exist when the changes were originally made.
+- The trailing commit's body cannot give a coherent rationale, because the diff has nothing in common across its files except that "tooling said so."
+
+Format and tidy as you go. The cost per commit is trivial; the cost of the trailing dump compounds.

--- a/golang-dev/skills/planning-commits/examples/decision-rationale-layering.md
+++ b/golang-dev/skills/planning-commits/examples/decision-rationale-layering.md
@@ -1,0 +1,40 @@
+# Decision rationale layered across two layers
+
+A meaningful decision — an architectural choice, a policy switch, an API contract — deserves its own commit even when it does not introduce or remove a dependency. Such a commit creates two layers of rationale:
+
+- The **WHY-INTRINSIC**, embedded as comments or docstrings on the code that implements the decision.
+- The **WHY-EXTRINSIC**, captured in the commit body, recording the surrounding story the code itself cannot show.
+
+These two layers serve different readers. Code comments help the reader of the file as it stands today. The commit body helps the reader of `git blame` reconstructing why the decision was taken at that point in time, and which alternatives were considered.
+
+## Plan entry
+
+A team adding a retry policy to its HTTP client might plan as:
+
+```
+1. Introduce a retry policy with exponential backoff and full jitter
+   Add the retry wrapper around the existing client transport. The
+   inline comments name the algorithm and the cap. The commit body
+   documents the alternatives that were considered — decorrelated
+   jitter, no jitter, fixed delay — and why full jitter won for
+   this workload (downstream service tolerates burstiness poorly,
+   all clients are long-lived).
+
+2. Apply the retry policy to the payments call site
+   Wrap only the payments client call site. Other call sites retain
+   their current behaviour and migrate in later commits as their
+   owners validate the policy's fit.
+```
+
+## What this demonstrates
+
+The atomic facet, in its decision-layering form. Commit 1's diff is small but its commit body is where the next engineer reading `git blame` learns why the team did not pick decorrelated jitter, fixed delay, or any other reasonable alternative. That knowledge survives long after the original conversation is forgotten.
+
+The isolation has two practical consequences:
+
+- **Granular revert.** If the chosen policy proves wrong, the revert affects only commit 1. The call-site applications in commit 2 (and onward) can be retargeted to a different policy without losing the migration progress.
+- **Isolated effect evaluation.** Performance, error-rate, and latency comparisons can be attributed to commit 1 specifically. A reviewer or operator investigating a regression bisects to the decision commit, not to a mixed commit where the policy choice and its applications are tangled together.
+
+## Where this differs from the dependency example
+
+The dependency-adoption pattern (see `examples/dependency-adoption-isolated.md`) is the narrow case of this rule, limited to "which library do we depend on". This example is the general form: any decision that future readers will need to defend or revisit benefits from its own commit and the layered rationale.

--- a/golang-dev/skills/planning-commits/examples/dependency-adoption-isolated.md
+++ b/golang-dev/skills/planning-commits/examples/dependency-adoption-isolated.md
@@ -1,0 +1,45 @@
+# Dependency adoption is its own commit
+
+When the work introduces a new third-party dependency — a Go module, npm package, Cargo crate, Python distribution, system tool — the decision to depend on it deserves its own commit. The commit body documents the alternatives considered and the reasoning behind the choice.
+
+## Plan entry
+
+A feature that needs structured logging might plan as:
+
+```
+1. Adopt slog/zerolog/zap as the structured logging dependency
+   Add the chosen module to go.mod / package.json / Cargo.toml with
+   no callers yet. The commit body lists the top alternatives that
+   were evaluated, the criteria that distinguished them (allocation
+   profile, API ergonomics, ecosystem fit, maintenance posture),
+   and why this choice won. Lockfile updates land in this commit
+   too.
+
+2. Replace fmt-style logging in pkg/server
+   Migrate the server package's existing log.Printf calls to the
+   new logger. The diff is mechanical; the value is that the new
+   dependency now has a real caller and the migration's first
+   shape is visible.
+
+3. Replace fmt-style logging in pkg/worker
+   Same migration for the worker package, separated because the
+   worker's logging contract differs (structured fields for job
+   IDs, retry counts) and is worth reviewing on its own.
+```
+
+## What this demonstrates
+
+The atomic facet, in its decision-layering form. Commit 1 captures a single decision — which structured logger to depend on — and its body is the durable record of why. Six months later, when somebody asks "why did we pick this and not the other one?", `git log` answers the question precisely.
+
+Isolating the dependency also makes the decision revertable. If the choice proves wrong, the revert affects only commit 1 (and any later commits that consume the dependency, which can be re-targeted). A reviewer evaluating commit 1 alone decides the dependency question without their attention being split across migration noise.
+
+## What the commit body should contain
+
+The body of the dependency-adoption commit is the WHY-EXTRINSIC of the decision:
+
+- The top alternatives considered, named explicitly.
+- The criteria that distinguished them.
+- Which criterion won this choice, and which trade-offs were accepted.
+- Any non-obvious constraints (licence, transitive dependencies, build-time impact).
+
+The code's own comments (the WHY-INTRINSIC) explain how the chosen library is used. The commit body explains why it is the chosen library.

--- a/golang-dev/skills/planning-commits/examples/docs-with-feature.md
+++ b/golang-dev/skills/planning-commits/examples/docs-with-feature.md
@@ -33,6 +33,6 @@ The incremental facet. Each commit's documentation describes only what exists on
 
 ## Non-linear is fine
 
-The README is built in logical narrative order, not top-to-bottom file order. Commit 1 might land the introduction and the encoder section. Commit 2 might insert a "round-trip" section between them. Commit 3 might append the streaming section while also revising the introduction to mention performance trade-offs. The READMEs final paragraph order need not match the order of the commits that produced it.
+The README is built in logical narrative order, not top-to-bottom file order. Commit 1 might land the introduction and the encoder section. Commit 2 might insert a "round-trip" section between them. Commit 3 might append the streaming section while also revising the introduction to mention performance trade-offs. The README's final paragraph order need not match the order of the commits that produced it.
 
 What stays invariant: every commit's README state describes a working product whose features all exist as of that commit. Never write a sentence that depends on a future commit to be true.

--- a/golang-dev/skills/planning-commits/examples/docs-with-feature.md
+++ b/golang-dev/skills/planning-commits/examples/docs-with-feature.md
@@ -1,0 +1,38 @@
+# Docs ship with the feature they describe
+
+Documentation belongs in the commit that introduces the feature it describes — not in a trailing "documentation" commit at the end of the series. The same rule applies to package overviews, README sections, code comments, and any user-facing guide.
+
+## Plan entry
+
+A library that grows three new public APIs across a series might plan as:
+
+```
+1. Expose Encoder with the encoding overview
+   Land the Encoder type, its methods, and the package doc section
+   that frames "what this package does and when to reach for it".
+   The README's introductory paragraph also lands now, because it
+   describes the encoder as the entry point.
+
+2. Expose Decoder with its reciprocity guarantees
+   Add the Decoder type alongside the README section describing how
+   it pairs with Encoder, including the round-trip guarantee. The
+   doc text exists because the guarantee exists; both arrive in this
+   commit.
+
+3. Add streaming support with the performance section
+   Land the streaming variants of both Encoder and Decoder, plus the
+   README's "performance characteristics" section that documents the
+   memory profile of the streaming path versus the buffered path.
+   This is the first commit where comparative performance is a real
+   distinction in the API.
+```
+
+## What this demonstrates
+
+The incremental facet. Each commit's documentation describes only what exists on the branch as of that commit, never forward-references unwritten features, and grows the user-facing narrative one capability at a time. A reader of `git blame` on the README's streaming section finds the commit where streaming was introduced — not a separate docs commit two weeks later.
+
+## Non-linear is fine
+
+The README is built in logical narrative order, not top-to-bottom file order. Commit 1 might land the introduction and the encoder section. Commit 2 might insert a "round-trip" section between them. Commit 3 might append the streaming section while also revising the introduction to mention performance trade-offs. The READMEs final paragraph order need not match the order of the commits that produced it.
+
+What stays invariant: every commit's README state describes a working product whose features all exist as of that commit. Never write a sentence that depends on a future commit to be true.

--- a/golang-dev/skills/planning-commits/examples/flags-grow-with-features.md
+++ b/golang-dev/skills/planning-commits/examples/flags-grow-with-features.md
@@ -1,0 +1,32 @@
+# Flags grow with the features they enable
+
+A command-line tool, server, or library accumulates flags as it gains capabilities. The temptation is to land all anticipated flags up front so the wiring is "ready" for later work. Resist this: a flag without a feature behind it has no behaviour to demonstrate, test, or document.
+
+## Plan entry
+
+A multi-step build-out of an HTTP server might plan as:
+
+```
+1. Land the server skeleton and the --addr flag
+   Wire main(), the listener, and the only flag the skeleton actually
+   needs: the bind address. The server logs requests and returns 204
+   to everything. Flags for behaviours that do not yet exist
+   (--timeout, --rate-limit, --metrics) wait for their respective
+   features.
+
+2. Handle the /healthz endpoint and add --health-timeout
+   Implement the readiness check this endpoint exposes, and add the
+   flag that governs its threshold. The flag arrives with the feature
+   that consumes it.
+
+3. Apply per-route rate limiting and add --rate-limit
+   The rate-limit token bucket lands together with the flag that
+   configures its rate. The default matches the unlimited behaviour
+   from commits 1 and 2, so the introduction is non-breaking.
+```
+
+## What this demonstrates
+
+The atomic facet, expressed through value-grouping. Each commit's flag is part of the same value increment as the feature it controls. Reading commit 3 alone tells a reviewer everything about why `--rate-limit` exists and what its default means — they do not have to scan an earlier flag block hoping to find the rationale.
+
+It also avoids dead-on-arrival configuration. A flag introduced before its feature has no test coverage, no documentation grounded in observable behaviour, and no way to defend its name or default against later requirements.

--- a/golang-dev/skills/planning-commits/examples/go-mod-get-before-use.md
+++ b/golang-dev/skills/planning-commits/examples/go-mod-get-before-use.md
@@ -1,0 +1,42 @@
+# go.mod: get one module per commit, ahead of the first caller
+
+When a Go changeset introduces new module dependencies, each `go get` lands as its own commit ahead of the commit that consumes it. The diff is scoped to exactly that one module — `go.mod` adds one top-level `require`, `go.sum` carries the corresponding entries, and nothing else.
+
+## Plan entry
+
+A Go feature that needs both an OpenTelemetry tracer and its OTLP exporter might plan as:
+
+```
+1. go.mod: get go.opentelemetry.io/otel
+   Run `go get go.opentelemetry.io/otel@<version>`, then `go mod
+   tidy`, then stage the resulting go.mod and go.sum diff. The
+   commit body lists the alternatives evaluated (OpenCensus,
+   vendor-specific SDKs) and why otel won. No production caller
+   imports it yet.
+
+2. go.mod: get go.opentelemetry.io/otel/exporters/otlp
+   Add the OTLP exporter the same way. Separate commit because the
+   exporter is a distinct decision: stdout, otlp, and a vendor SDK
+   were all candidates. Body documents why otlp won.
+
+3. Wire tracing into the request path
+   First commit where both modules are actually imported. Now the
+   feature commit's diff is exclusively the production code that
+   uses the dependencies adopted in commits 1 and 2.
+```
+
+## What this demonstrates
+
+The atomic facet, specialised to Go module management. Each `go.mod: get` commit is independently revertable: if the OTLP exporter choice proves wrong, the revert of commit 2 leaves commit 1's otel adoption intact and the feature work in commit 3 can be retargeted at a different exporter.
+
+This is the Go-flavoured form of the general dependency-adoption pattern (see `examples/dependency-adoption-isolated.md`), with the additional rule that one `go get` invocation introduces exactly one top-level require.
+
+## Why one module per commit
+
+A single `go get a/b a/c a/d` would land three require entries in one commit. Each was a different decision evaluated against its own alternatives, but the decision context is now smeared across all three. Reverting one rolls back all three.
+
+## Why `go mod tidy` before staging
+
+Running `go mod tidy` before staging ensures the commit's `go.sum` diff is exactly what the new module needs — no transitive churn from earlier drift in the working tree, no leftover `require` entries from previous spike branches. If `go mod tidy` produces a diff for modules other than the one just added, that diff belongs in a separate cleanup commit ahead of the series (see `examples/go-mod-tidy-first.md`).
+
+The test: `git diff --cached --stat` should show only `go.mod` and `go.sum` modified, and the `go.mod` portion should contain exactly one new top-level require line.

--- a/golang-dev/skills/planning-commits/examples/go-mod-tidy-first.md
+++ b/golang-dev/skills/planning-commits/examples/go-mod-tidy-first.md
@@ -1,0 +1,47 @@
+# Clean a contaminated working tree as the first commit
+
+When work begins in a working tree that is already dirty — `go.mod` has drift from a prior partial change, `go.sum` carries unused entries, generated code is stale, the package fails `gofmt` — the first commit of the series is the cleanup. The contamination does not get to spill into diffs that should be scoped to the feature.
+
+## Plan entry
+
+A feature added to a slightly-stale working tree might plan as:
+
+```
+1. go.mod: tidy
+   Run `go mod tidy` and stage the resulting go.mod and go.sum
+   diff. The commit's only purpose is to bring the module manifest
+   to a clean baseline before feature work begins. No new
+   dependencies, no source changes. Body notes the drift removed
+   when non-obvious (e.g., "removes unused require lines left over
+   from a previously reverted dependency spike").
+
+2. [first feature commit]
+   Now the feature commit's diff is scoped to the feature itself.
+```
+
+When the contamination is from a different tool, use a target that names what was cleaned:
+
+- `gofmt: format the package` for accumulated gofmt drift
+- `generate: refresh generated files` for stale `go generate` output
+- `golangci-lint: apply auto-fixes` when the lint config changed and auto-fixable findings accumulated
+
+Each is a single mechanical commit, ahead of the feature work. Each commit's diff is exclusively that tool's output.
+
+## What this demonstrates
+
+The atomic facet. If hygiene work is mixed with the first feature commit, that commit's diff carries two unrelated concerns: the feature itself and a cleanup that has nothing to do with the feature. A reviewer cannot evaluate either in isolation, and the commit body has to either omit the cleanup (misleading) or list both (diluting the feature's rationale).
+
+It also keeps the contamination from compounding. A `go mod tidy` deferred to mid-series will pick up not only the original drift but every transitive change the intervening commits introduced — the resulting diff becomes impossible to attribute.
+
+## How to detect contamination before planning
+
+Before drafting the sequence, inspect the starting state:
+
+```bash
+git status
+go mod tidy && git diff --stat go.mod go.sum
+gofmt -l .
+go vet ./...
+```
+
+If any of these produces a non-empty result before the work starts, the contamination is real and a cleanup commit belongs at the head of the plan. If they are all clean, skip directly to the feature commits.

--- a/golang-dev/skills/planning-commits/examples/siblings-by-decision.md
+++ b/golang-dev/skills/planning-commits/examples/siblings-by-decision.md
@@ -1,0 +1,39 @@
+# Siblings by decision context
+
+Three endpoints, three RPC methods, three commands, three subscribers — surface-level siblings that look like they belong together. The temptation is to land them as one commit: "add the three health endpoints." Resist this when each sibling carries a distinct decision context, even if their wiring is similar.
+
+## Plan entry
+
+A Kubernetes-facing service exposing the three probe endpoints might plan as:
+
+```
+1. Wire /healthz as a liveness signal
+   The endpoint returns 200 unconditionally once the process has
+   started. Document in code and README that this is the liveness
+   contract: the answer is "is the process alive?", not "is the
+   process working?". The narrow contract is the decision worth
+   isolating.
+
+2. Wire /readyz to gate traffic on dependency reachability
+   The endpoint returns 200 only once startup probes against the
+   database and message bus have succeeded. The set of checked
+   dependencies is the decision worth isolating — it determines
+   when this pod accepts traffic from the service mesh, distinct
+   from whether it should be restarted.
+
+3. Wire /livez as the kubelet's restart trigger
+   The endpoint returns 200 unless an internal watchdog has flagged
+   an unrecoverable state (deadlock, exhausted goroutine pool). The
+   restart criteria are the decision worth isolating, and they are
+   strictly stronger than /healthz's "process alive" check.
+```
+
+## What this demonstrates
+
+The atomic facet. The three endpoints share handler shape and routing, but each lands in its own commit because each answers a different question. A reviewer evaluating commit 2 in isolation can debate which dependencies belong in the readiness set without their attention being split across the other two endpoints.
+
+A single "add health endpoints" commit would force the reviewer to either evaluate all three contracts at once (cognitive overload) or skim past contracts they care less about (review hygiene loss). Splitting by decision context makes each contract independently revertable, evaluable, and rebaseable.
+
+## Compare with mechanical splits
+
+Splitting the same work by syntactic role — "all handlers in commit 1, all routes in commit 2, all tests in commit 3" — would produce three commits that nobody can review in isolation, because the value of any one is distributed across all three.

--- a/golang-dev/skills/planning-commits/examples/skeleton-first.md
+++ b/golang-dev/skills/planning-commits/examples/skeleton-first.md
@@ -1,0 +1,20 @@
+# Skeleton-first package or module introduction
+
+When starting a new package, module, command, or significant subsystem, the first commit lays the ground: package documentation, goal, user story, and optionally no-op functions or type sketches with intent. It contains no production implementation — those land in subsequent commits as each piece is designed.
+
+## Plan entry
+
+```
+1. Introduce the package with its goal and user story
+   Land doc.go (or the equivalent) describing what this package will
+   do, who needs it, and the constraints driving its design. Include
+   any type sketches or no-op signatures that name the eventual
+   surface, but no implementations. The commit must not reference
+   symbols or behaviours that do not yet exist on this branch.
+```
+
+## What this demonstrates
+
+The incremental facet. The skeleton commit names the goal without forward-referencing implementations that have not yet been written. A reader of `git blame` for the package doc sees the original intent — not a retrospective summary written after the package was already complete.
+
+It also keeps the first commit reviewable on its own terms. A reviewer can confirm the design intent before any implementation discussion begins, which surfaces disagreements early when the cost of changing direction is still low.

--- a/golang-dev/skills/planning-commits/references/plan-shape.md
+++ b/golang-dev/skills/planning-commits/references/plan-shape.md
@@ -1,0 +1,48 @@
+# Plan Shape
+
+The output of planning is a plan — not a series of commit messages. Each entry in the plan describes one upcoming commit in just enough detail to commit to its scope, no more.
+
+## Entry shape
+
+Each entry has two parts:
+
+**Scope.** A single sentence describing what this commit changes. It is a one-liner, not a properly-formed commit message. Choosing the target, the verb, and the phrasing that meets any repository convention happens later, when the commit-message-writing skill takes over.
+
+**Context.** A paragraph explaining why this commit, why now, and what it deliberately does not include. Capture the constraints, decisions, and trade-offs that justify treating these changes as one reviewable unit. This is the rationale a future reader will look for in the commit body — but at planning time it lives in the plan, not in a written message.
+
+## Hand-off to the message-writing skill
+
+The plan is consumed one entry at a time. For each commit:
+
+1. Stage only the changes for that entry's scope.
+2. Load the commit-message-writing skill appropriate to the repository. In a Go-centric repository, that is `golang-dev:committing`.
+3. Let that skill choose the target, verb, and body voice. Pass the entry's scope and context as input.
+
+Keep planning and naming separate. Solving both at once overwhelms the working set and produces weaker output on both axes. A plan entry that reads like a good commit message is a sign of premature naming — strip it back to plain prose before continuing.
+
+## Mini-example
+
+A change adding rate limiting to an HTTP client might plan as:
+
+```
+1. Introduce a token bucket with no callers
+   Land the bucket type, its constructor, and its acquire/release
+   methods alongside table-driven tests. No production caller wires
+   it in yet, so the commit stands alone as a self-contained primitive
+   that a reviewer can evaluate without tracing it through the rest
+   of the request path.
+
+2. Apply the bucket to outbound requests
+   Wrap the existing transport so each request acquires a token before
+   issuing the network call. Add an integration test that exercises
+   the limit under concurrent load. The bucket from the previous
+   commit is now load-bearing.
+
+3. Make the limit configurable via flag
+   Expose the rate as a flag with a default that matches current
+   behaviour. Document the flag in the package README. The flag
+   arrives only now, because there is finally a feature that varies
+   with it.
+```
+
+Each entry's scope is a single sentence; the lines that follow are the context paragraph. None of these entries is a commit message; the writing skill produces those when each commit is staged.

--- a/golang-dev/skills/planning-commits/references/triad.md
+++ b/golang-dev/skills/planning-commits/references/triad.md
@@ -1,0 +1,29 @@
+# The Triad: Atomic, Fine-Grained, Incremental
+
+A single coherent rule with three facets, not three independent adjectives. A commit plan satisfies all three together.
+
+## Atomic
+
+Group changes by value — by user-facing capability, by feature, by single decision — never by syntactic category. The test: each commit advances one identifiable piece of value that can be reverted, evaluated, or rebased in isolation from its neighbours.
+
+This rules out the groupings an LLM agent tends to default to:
+
+- All types in one commit, then all functions in the next
+- All interfaces first, then all implementations
+- All handlers, then all routes, then all tests
+
+Three sibling endpoints `/healthz`, `/readyz`, `/livez` belong in three separate commits because each carries a distinct decision context — not in one "add health endpoints" commit, and not split by handler/route/test layer.
+
+When a commit captures a single decision, its body carries the WHY-EXTRINSIC rationale on top of the code's WHY-INTRINSIC comments. The decision is then revertable in isolation and its downstream effects are easier to evaluate.
+
+## Fine-grained
+
+One reviewable change per commit. An enhancement may touch several files or several fields if they belong to the same value increment; the test is reviewability, not file count.
+
+A two-line diff is fine-grained if it lands one cohesive change. A fifty-file diff is not fine-grained even when every individual edit is small — the reviewer cannot hold the change in their head as a single decision.
+
+## Incremental
+
+Build the final value over a planned sequence of commits. Start with a skeleton — package doc, README outline, type sketch, no-op functions with intent — that names the goal without forward-referencing implementations that do not yet exist on the branch. Then layer capabilities, one per commit.
+
+Flags grow with the features that need them; never land flags up front. Docs travel with the commit that introduces the feature they describe; never accumulate into a trailing docs-dump commit. Tests interleave with the code they exercise; never batch them at the end.

--- a/golang-dev/skills/planning-commits/references/triad.md
+++ b/golang-dev/skills/planning-commits/references/triad.md
@@ -27,3 +27,5 @@ A two-line diff is fine-grained if it lands one cohesive change. A fifty-file di
 Build the final value over a planned sequence of commits. Start with a skeleton — package doc, README outline, type sketch, no-op functions with intent — that names the goal without forward-referencing implementations that do not yet exist on the branch. Then layer capabilities, one per commit.
 
 Flags grow with the features that need them; never land flags up front. Docs travel with the commit that introduces the feature they describe; never accumulate into a trailing docs-dump commit. Tests interleave with the code they exercise; never batch them at the end.
+
+Formatting, tidying, and other mechanical hygiene happen within the commit that produced the change, never deferred to a trailing dump. Each commit's diff is scoped to its own value — the production change plus the cleanup that change itself implies. When the working tree starts contaminated (drift from prior partial work), the cleanup is its own first commit; after that, every subsequent commit holds the line.


### PR DESCRIPTION
The golang-dev:committing skill assumed a commit plan already existed when it ran. Its only nod to planning was a one-line "consider splitting into separate commits" in Mixed Changes, with no guidance on how. In practice the missing concern recurred across recent sessions: agents consistently defaulted to syntactic groupings — all types in one commit, all handlers in another, all flags up front, all docs in a trailing dump — and the same user explanation about value-grouping atomicity had to repeat each time.

This change introduces golang-dev:planning-commits as a sibling skill dedicated to sequencing atomic, fine-grained, incremental commits before any code is written or any commit message is drafted. Planning and message-writing become two distinct cognitive steps: planning-commits produces a plan (numbered list where each entry is a single sentence of scope plus a paragraph of context), and committing then consumes each entry to produce the actual commit message. Splitting the concerns keeps either step from being overwhelmed by the other's working set, which matters most when an LLM is on either side of the hand-off.

This builds on notorious-ai/claude-plugins#26's tightening of the committing skill's body discipline by addressing the prior step that #26 assumed was already handled: the choice of what each commit contains.

The skill encodes a triad reference (atomic / fine-grained / incremental, with the value-vs-syntactic distinction stated explicitly), a plan-shape reference defining the deliverable and its hand-off contract, eight positive examples covering common decision shapes including Go-specific go.mod patterns, and six anti-pattern examples covering the syntactic-grouping failure modes plus the trailing docs and format dumps. The per-commit-hygiene principle — formatting and tidying happen within each commit, never as a trailing dump — is stated language-agnostically and defers to per-repo tool awareness rather than naming specific formatters.

Trigger language is language-agnostic; the skill lives under golang-dev for now because the work began as a refinement of golang-dev:committing. A future commit-craft plugin is the planned long-term home for language-agnostic commit-authoring skills (planning-commits, plus an extracted core of the message-writing rules currently in committing). Until that plugin exists, the Go-flavoured examples colocate with the Go-flavoured message-writing skill, and committing cross-references planning-commits in its Mixed Changes special case.

Out of scope for this change: relocating planning-commits to commit-craft (that plugin does not exist yet), revising committing beyond the one cross-reference bullet, and encoding rules for specific formatters or tidy tools.

## Test plan
- Install locally via `claude --plugin-dir <path>` and confirm both committing and planning-commits load.
- Ask "plan commits for X" on a multi-capability changeset; confirm the response is a numbered list of single-sentence scopes plus paragraph contexts, not commit messages.
- Trigger proactively: start a feature task in a Go repo and confirm planning-commits loads ahead of committing without explicit invocation.
- Read golang-dev:committing's Mixed Changes section and confirm the cross-reference to planning-commits is the first bullet.