### PR TITLE
Teach the standard for committed Go tests and how to review a suite

### DIFF
--- a/golang-dev/.claude-plugin/plugin.json
+++ b/golang-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "golang-dev",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Comprehensive Go development experience - skills that elevate Claude into the ultimate Golang developer",
   "author": {
     "name": "Daniel Orbach"

--- a/golang-dev/CHANGELOG.md
+++ b/golang-dev/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## testing
+
+Initial release of the testing skill for committed Go tests.
+
+- Golden hierarchy of contract authority running from the package's prose down to its existing tests, with drift surfaced as a finding instead of absorbed into a new test
+- Package-as-unit doctrine: an external test package, anticipated call patterns over symbol-by-symbol scans, and one representative runnable example required per package
+- Go-doc-first planning, drafting the test plan from the exported documentation alone before any source file is opened
+- Role-split routing where writers read only the exemplar samples matching their package's clusters while reviewers read the corpus whole
+- Eight exemplar files of verbatim, attributed Go-team snippets, serving the transform, lifecycle, stream, contract-conformance, harness, golden-fixture, async-assert, and example archetypes
+- Six scenario references covering helpers and fakes, tables and sub-tests, fixtures, runnable examples, concurrency and time, and conformance harnesses
+- Reviewer-only calibration cases pairing a shape a grader must not flag with the near-neighbour it must
+- Owner-only boundary keeping a reviewer of tests out of exported source and prose, with drift findings routed to the report
+
 ## planning-commits
 
 Encode per-commit hygiene as part of the incremental facet.

--- a/golang-dev/README.md
+++ b/golang-dev/README.md
@@ -17,12 +17,13 @@ This plugin shapes Claude into a **professional Go developer** who thinks and ac
 
 - **committing** - Write commit messages that match Go project conventions for all files in Go-centric codebases
 - **naming** - Name Go identifiers following Go team conventions
+- **planning-commits** - Plan a fine-grained sequence of atomic commits before the first line of code lands
+- **testing** - Hold committed Go tests to the maintainer's standard, and review a suite against it
 
 ### Tier 2 (Planned)
 
 - go-style-guide - The Go Way: idiomatic patterns and conventions
 - go-documentation - Writing Go docs that match godoc standards
-- go-testing-strategies - Test like the Go team
 
 ### Tier 3 (Future)
 

--- a/golang-dev/skills/testing/SKILL.md
+++ b/golang-dev/skills/testing/SKILL.md
@@ -43,3 +43,34 @@ its promises. Drift is a finding, never silently absorbed: ask the owner,
 else side with prose unless the code moved deliberately, then fix the prose.
 Go-doc-first makes this operational: draft the test plan from go doc -all
 alone, no bodies, before opening source, so every collision is surfaced drift.
+
+## The unit is the package
+
+Go's objects are packages, not files or symbols. Exercise each package as
+its user, in an external `package foo_test` that enforces the user's seat
+at compile time, unless a peephole into internals is required. Thinking as
+a user tests flows, the anticipated call patterns that embody the contract,
+not a symbol-by-symbol scan. Aspire to fewer tests that cover more of the
+exported API, because users compose the API rather than call it piecemeal.
+
+When asked to add a test for one symbol, first see whether it fits an
+existing test as a sub-test or table row; usually it will not, and a
+runnable example is the next reach. A bug-hunt request gets run, not
+committed. A symbol extending the API gets tested the way its siblings are.
+
+A representative runnable example of the anticipated call pattern is
+mandatory per package; an ExampleLoad that just calls Load earns no commit.
+Example comments, doc and in-function alike, render on pkgsite: they speak
+to users about the attributed symbol and scenario, repeating non-Go
+contract parts at call sites, never narrating the code. Test comments speak
+only to maintainers: a non-trivial test carries a doc comment giving the
+author's rationale in layman's terms, a trivial one needs none, and no test
+comment ever opens with the function's name. Never explain conventions,
+ordering, or synctest mechanics: nothing good to say, say nothing. A test
+name claims a property in plain English, not a symbol; a whole-package
+scenario test named for the package is good. Bodies are trivial
+straight-line code: hard-coded numbers, not algorithms, the math done at
+coding time and written as results. Canon postdating training data: b.Loop
+benchmarks (Go 1.24), which the compiler keeps alive where old b.N
+discard-loops optimize away, and t.Context() (Go 1.24), canceled just
+before Cleanup so context-shutdown resources drain in time.

--- a/golang-dev/skills/testing/SKILL.md
+++ b/golang-dev/skills/testing/SKILL.md
@@ -24,6 +24,24 @@ when_to_use: >-
 
 # Committed Go Tests
 
+Imitation is the method, split by role. The `exemplar/` files are annotated
+verbatim snippets from the Go team's own packages; imitate them, because
+canon is the source and nothing bundled is canon of its own. WRITING tests:
+after go doc -all, match the package's disjoint symbol clusters to
+archetypes via exemplar/README.md and read ONLY the matched samples, as
+inspiration — generation is creative synthesis; the review loop carries the
+nuance load. REVIEWING or critiquing tests: read the whole exemplar corpus
+with its annotations — evaluation is discrimination; the corpus is your
+grading sense, calibrated by references/evaluator-cases.md, the rulings
+evaluators mis-graded before. Load references on scenario, not sooner:
+
+- `references/helpers.md` — a test wants a helper, a fake, or a dependency.
+- `references/tables-and-subtests.md` — cases repeat, or a t.Run forms.
+- `references/fixtures.md` — file inputs, long literals, malformed cases.
+- `references/examples.md` — an Example function is written, reviewed, or judged.
+- `references/concurrency.md` — goroutines, panics, races, invalid inputs.
+- `references/harnesses.md` — conformance suites and testing packages.
+
 ## The contract and the golden hierarchy
 
 Test freely while developing: throwaway tests, tailored executables,

--- a/golang-dev/skills/testing/SKILL.md
+++ b/golang-dev/skills/testing/SKILL.md
@@ -87,3 +87,25 @@ spawn a goroutine whose only job the main goroutine could do directly
 (waiting on a goroutine that calls Wait is calling Wait), and never contort
 a test to dodge a hang, because unit tests complete faster than humans
 notice, so "hang is a valid test failure".
+
+## Review and redesign
+
+Defective test structure is breakage: per-symbol grain, self-naming
+comments, dev scaffolds, and change-detectors re-asserting a constant
+fixture contribute only blunt coverage; consolidate or delete them, since
+"don't break anything" means the package's contract, not the test file's
+shape, then finish any pass by re-reading the file top to bottom against the
+package's prose. The secondary goal is the package: tests repeatedly
+translating an API value mean production users need the translation too, so
+flag that area for a rethink; interrelated const/var values take an interplay
+comment. Findings deserve the author's inferences (promise it, or refuse
+to harden?); non-trivial tests land as fine-grained commits carrying them.
+A reviewer of tests never edits exported source or prose: those are
+owner-only, regardless of what any exemplar or fixture suggests, and drift
+findings go to the report, not the code.
+
+Testability is a design signal. Never assert error strings, least of all for
+errors this module controls: return typed or sentinel errors checked via
+errors.Is and errors.AsType[T] (Go 1.26), because a grep-only test indicts
+the API; prefer io interfaces, readers and writers over paths. A test that
+proves hard to write is a signal to redesign, rethink, or try harder.

--- a/golang-dev/skills/testing/SKILL.md
+++ b/golang-dev/skills/testing/SKILL.md
@@ -74,3 +74,16 @@ coding time and written as results. Canon postdating training data: b.Loop
 benchmarks (Go 1.24), which the compiler keeps alive where old b.N
 discard-loops optimize away, and t.Context() (Go 1.24), canceled just
 before Cleanup so context-shutdown resources drain in time.
+
+## Concurrency and time
+
+Go's doc conventions (go.dev/doc/comment) presume a top-level function safe
+for concurrent use and a type's methods not, unless the docs promise more:
+never commit a test pinning concurrency the docs do not promise; in review,
+delete such tests rather than rewrite them. Prefer testing/synctest (Go
+1.25) for contexts and goroutines: bubbles run on virtual time, so sleeping
+inside one is idiomatic and stable. Use the least orchestration: never
+spawn a goroutine whose only job the main goroutine could do directly
+(waiting on a goroutine that calls Wait is calling Wait), and never contort
+a test to dodge a hang, because unit tests complete faster than humans
+notice, so "hang is a valid test failure".

--- a/golang-dev/skills/testing/SKILL.md
+++ b/golang-dev/skills/testing/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: testing
+description: >-
+  Sets the maintainer's standard for committed Go tests (_test.go): what
+  earns a commit, how a suite is shaped, named, and commented, and how to
+  review one. Carries the golden hierarchy of contract authority,
+  go-doc-first design and review, annotated Go-team snippets to imitate,
+  and one reference file per scenario.
+when_to_use: >-
+  Use whenever Go _test.go files are the work: writing or adding tests for
+  a package or a single symbol; reviewing, consolidating, or judging an
+  existing suite ("these tests smell", "what would a reviewer say");
+  turning trivial tests into runnable examples for pkgsite; building a
+  conformance harness so other implementations can prove they satisfy an
+  interface; shaping a new package's API so it stays testable before the
+  code exists; rescuing a test that flakes or resists being written. Load
+  it after writing or changing any Go code, since committed tests are part
+  of done: do not wait for the word "test". Begin in go-doc-first mode,
+  planning from the exported docs before opening source, and enter
+  exemplar/ by role, matched samples to write and the whole corpus to
+  review. Not for non-Go test frameworks, godoc-only tasks, go vet or CI
+  tooling failures, fuzz-crash debugging, or test-plan process documents.
+---
+
+# Committed Go Tests
+
+## The contract and the golden hierarchy
+
+Test freely while developing: throwaway tests, tailored executables,
+build-tagged experiments, runs under constrained CPU (a weak-runner flake
+is a contract failure too). None of it gets committed: committed _test.go
+files carry only the package's contract with its users, so a breaking
+change either fails the tests or amends them to state the new contract;
+unit tests are rapid iteration against a contract, not bug hunts.
+
+The package's prose, the package doc and exported doc comments that godoc
+publishes and users rely on, is the most sacred part of its contract.
+Authority descends through exported signatures, code behavior, and
+unexported comments, down to the existing tests: the least golden thing in
+the room, never the standard. A test authored from the implementation
+mirrors it, bugs included; one authored from the prose holds the package to
+its promises. Drift is a finding, never silently absorbed: ask the owner,
+else side with prose unless the code moved deliberately, then fix the prose.
+Go-doc-first makes this operational: draft the test plan from go doc -all
+alone, no bodies, before opening source, so every collision is surfaced drift.

--- a/golang-dev/skills/testing/exemplar/README.md
+++ b/golang-dev/skills/testing/exemplar/README.md
@@ -1,0 +1,43 @@
+# Exemplar — annotated Go-team snippets
+
+Verbatim test code from the Go standard library, chosen because the Go team's
+practice is the source of this skill's doctrine: you imitate canon, and nothing
+bundled is canon of its own. Nothing here is agent-written or eval-derived; the
+only code allowed in this folder is attributed snippets from the Go team's
+packages (standard library and golang.org/x). The annotations are ours and say
+what to imitate and why.
+
+Each snippet sits in a `<sample id archetypes source lines>` element carrying
+one `<highlight archetype="...">` per archetype and a `<note>` for the general
+lesson. WRITING tests: match your package's symbol clusters from `go doc -all`
+to the archetypes below and read ONLY the matched samples; `file#id` names the
+`<sample id="id">` element in `file.md`. REVIEWING tests: read every file end
+to end; the whole corpus is the grading sense.
+
+## Archetypes
+
+- transform — top-level pure funcs mapping inputs to outputs, often a family sharing one signature shape (`Index`/`LastIndex`/`IndexAny`). → strings#case-table, strings#family-shared-runner, strings#bloop-benchmark, hash-maphash#property-claim-names, hash-maphash#one-invariant-many-paths
+- lifecycle — a constructor returning `*T` that owns background work (pools, workers, expiry timers) and must be shut down; the shutdown wears many signature shapes (`Close() error`, `Stop()`, `Shutdown(context.Context) error`, names inconsistent across packages), so recognize it by language-reasoning over the docs and signatures — they are more than enough for the vast majority of cases; never peek at code bodies to classify. → database-sql#matrix-runner, database-sql#wait-before-read, database-sql#bubble-sleep-expiry
+- stream — incremental `Read`/`Write`/`WriteByte` methods or io interfaces in signatures, begging tiny bespoke fakes. → io#one-behavior-fakes, io#regression-to-property, hash-maphash#one-invariant-many-paths
+- contract-conformance — a type documented to implement a published interface (`fs.FS`, `io.Reader`) whose owner ships a verifier. → archive-zip#verifier-shape, archive-zip#conformance-call
+- harness — a case corpus or variant matrix wanting one composition point: a shared runner func, one expectation language. → go-parser#harness-header-doc, go-parser#error-marker-language, go-parser#fixture-inline-expectations, database-sql#matrix-runner, cmd-gofmt#corpus-glob-idempotence, strings#family-shared-runner, archive-zip#verifier-shape
+- golden-fixture — outputs too large to inline: expected bytes live in testdata beside their inputs, refreshed by an `-update` flag. → cmd-gofmt#update-flag-diff, cmd-gofmt#corpus-glob-idempotence, cmd-gofmt#flag-in-fixture, go-parser#fixture-inline-expectations
+- async-assert — docs promising behavior after goroutines settle or time passes (expiry, delivery, draining). → database-sql#wait-before-read, database-sql#bubble-sleep-expiry
+- example — the mandatory runnable Example and its pkgsite voice; this archetype matches EVERY package. → encoding-json#example-user-voice, encoding-json#example-self-naming-violation, strings#example-edge-case
+
+One file per source package. Each names its source file and line ranges;
+elisions are marked. Verify against the tree before trusting an edit.
+
+## Finding samples
+
+Whole-file Read of a matched file is the default (every file is small).
+For cross-file queries, from this directory (invariants: tags start at
+column 0; `id` is the first attribute; per-file <sample> open/close
+counts always match):
+
+```bash
+awk '/^<sample id="case-table"/,/^<\/sample>/' strings.md          # one sample by id
+grep -o '^<sample id="[^"]*"' strings.md | cut -d'"' -f2           # ids in a file
+grep -El '^<sample .*archetypes="([^"]*,)?golden-fixture(,[^"]*)?"' *.md  # files serving an archetype
+awk '/^<highlight archetype="stream"/,/<\/highlight>/{print FILENAME": "$0}' *.md  # highlights by archetype
+```

--- a/golang-dev/skills/testing/exemplar/archive-zip.md
+++ b/golang-dev/skills/testing/exemplar/archive-zip.md
@@ -1,0 +1,88 @@
+# archive/zip — buying a whole interface contract with one verifier call
+
+Source: `archive/zip/reader_test.go` (Go development tree, 1.27 dev, 2026-06).
+Verbatim.
+
+<sample id="verifier-shape" archetypes="contract-conformance,harness" source="testing/fstest/testfs.go" lines="20-39">
+
+Source: `testing/fstest/testfs.go` lines 20-39 (Go 1.27 dev). Verbatim.
+The surface the next sample exercises.
+
+```go
+// TestFS tests a file system implementation.
+// It walks the entire tree of files in fsys,
+// opening and checking that each file behaves correctly.
+// Symbolic links are not followed,
+// but their Lstat values are checked
+// if the file system implements [fs.ReadLinkFS].
+// It also checks that the file system contains at least the expected files.
+// As a special case, if no expected files are listed, fsys must be empty.
+// Otherwise, fsys must contain at least the listed files; it can also contain others.
+// The contents of fsys must not change concurrently with TestFS.
+//
+// If TestFS finds any misbehaviors, it returns either the first error or a
+// list of errors. Use [errors.Is] or [errors.AsType] to inspect.
+//
+// Typical usage inside a test is:
+//
+//	if err := fstest.TestFS(myFS, "file/that/should/be/present"); err != nil {
+//		t.Fatal(err)
+//	}
+func TestFS(fsys fs.FS, expected ...string) error {
+```
+
+<highlight archetype="contract-conformance">When you implement an interface,
+call the owner's verifier before writing any bespoke test; when you own an
+interface, ship a verifier in this shape for implementers.</highlight>
+<highlight archetype="harness">The verifier shape matters: it takes no
+`*testing.T`, returns joined errors, and the caller decides
+severity.</highlight>
+
+<note>A published verifier turns an interface's documented contract into one
+callable check.</note>
+
+</sample>
+
+<sample id="conformance-call" archetypes="contract-conformance" source="archive/zip/reader_test.go" lines="1203-1229">
+
+Source: `archive/zip/reader_test.go` lines 1203-1229 (Go 1.27 dev). Verbatim.
+
+```go
+func TestFS(t *testing.T) {
+	for _, test := range []struct {
+		file string
+		want []string
+	}{
+		{
+			"testdata/unix.zip",
+			[]string{"hello", "dir/bar", "readonly"},
+		},
+		{
+			"testdata/subdir.zip",
+			[]string{"a/b/c"},
+		},
+	} {
+		t.Run(test.file, func(t *testing.T) {
+			t.Parallel()
+			z, err := OpenReader(test.file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer z.Close()
+			if err := fstest.TestFS(z, test.want...); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+```
+
+<highlight archetype="contract-conformance">zip implements `fs.FS`, so one
+`fstest.TestFS` call per archive buys the ENTIRE documented file-system
+contract — every Open, ReadDir, Stat clause, checked over the whole
+tree.</highlight>
+
+<note>The bespoke tests that follow in the source file cover only what `TestFS`
+cannot know: zip-specific contents and errors.</note>
+
+</sample>

--- a/golang-dev/skills/testing/exemplar/cmd-gofmt.md
+++ b/golang-dev/skills/testing/exemplar/cmd-gofmt.md
@@ -1,0 +1,126 @@
+# cmd/gofmt — golden beside fixture, -update, idempotence
+
+Samples: update-flag-diff, corpus-glob-idempotence, flag-in-fixture
+
+Source: `cmd/gofmt/gofmt_test.go` and `cmd/gofmt/testdata/rewrite1.input` (Go
+development tree, 1.27 dev, 2026-06). Verbatim.
+Note: `package main`, in-process — the gofmt binary is never executed.
+
+<sample id="update-flag-diff" archetypes="golden-fixture" source="cmd/gofmt/gofmt_test.go" lines="112-136">
+
+Source: `cmd/gofmt/gofmt_test.go` lines 112-136 (Go 1.27 dev). Verbatim.
+The tail of `runTest(t, in, out string)`; flag parsing and
+processing elided.
+
+```go
+	expected, err := os.ReadFile(out)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if got := buf.Bytes(); !bytes.Equal(got, expected) {
+		if *update {
+			if in != out {
+				if err := os.WriteFile(out, got, 0666); err != nil {
+					t.Error(err)
+				}
+				return
+			}
+			// in == out: don't accidentally destroy input
+			t.Errorf("WARNING: -update did not rewrite input file %s", in)
+		}
+
+		t.Errorf("(gofmt %s) != %s (see %s.gofmt)\n%s", in, out, in,
+			diff.Diff("expected", expected, "got", got))
+		if err := os.WriteFile(in+".gofmt", got, 0666); err != nil {
+			t.Error(err)
+		}
+	}
+}
+```
+
+<highlight archetype="golden-fixture">The golden discipline in one screen:
+`-update` rewrites the golden (but refuses to destroy an input), failures print
+a unified diff — never `%q` dumps — and the got-bytes land beside the fixture
+as `.gofmt` debris for inspection.</highlight>
+
+<note>Changing the formatter MUST edit a golden; that friction is the
+feature.</note>
+
+</sample>
+
+<sample id="corpus-glob-idempotence" archetypes="golden-fixture,harness" source="cmd/gofmt/gofmt_test.go" lines="138-169">
+
+Source: `cmd/gofmt/gofmt_test.go` lines 138-169 (Go 1.27 dev). Verbatim.
+
+```go
+// TestRewrite processes testdata/*.input files and compares them to the
+// corresponding testdata/*.golden files. The gofmt flags used to process
+// a file must be provided via a comment of the form
+//
+//	//gofmt flags
+//
+// in the processed file within the first 20 lines, if any.
+func TestRewrite(t *testing.T) {
+	// determine input files
+	match, err := filepath.Glob("testdata/*.input")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// add larger examples
+	match = append(match, "gofmt.go", "gofmt_test.go")
+
+	for _, in := range match {
+		name := filepath.Base(in)
+		t.Run(name, func(t *testing.T) {
+			out := in // for files where input and output are identical
+			if strings.HasSuffix(in, ".input") {
+				out = in[:len(in)-len(".input")] + ".golden"
+			}
+			runTest(t, in, out)
+			if in != out && !t.Failed() {
+				// Check idempotence.
+				runTest(t, out, out)
+			}
+		})
+	}
+}
+```
+
+<highlight archetype="golden-fixture">Expectations live beside fixtures: each
+`testdata/*.input` pairs with a `*.golden` sibling, per-fixture flags ride
+INSIDE the fixture as a `//gofmt` comment, and the package's own sources join
+the corpus as large examples.</highlight>
+<highlight archetype="harness">The cheapest strong property a formatter can pin
+closes the loop: re-run the formatter on its own golden and demand a fixed
+point (`runTest(t, out, out)`).</highlight>
+
+<note>Glob the corpus, name each sub-test by its fixture, and let one runner
+carry every case.</note>
+
+</sample>
+
+<sample id="flag-in-fixture" archetypes="golden-fixture" source="cmd/gofmt/testdata/rewrite1.input" lines="4-9">
+
+Source: `cmd/gofmt/testdata/rewrite1.input` lines 4-9 (copyright header elided; Go 1.27 dev). Verbatim.
+The paired rewrite1.golden is identical with `Foo` rewritten to
+`Bar`.
+
+```go
+//gofmt -r=Foo->Bar
+
+// (standard Go copyright header elided)
+
+package main
+
+type Foo int
+```
+
+<highlight archetype="golden-fixture">One case is one reviewable pair of files;
+the flag that produced the golden sits on line 1 of the input.</highlight>
+
+<note>Nothing about the case lives at helper-call distance in Go code.</note>
+
+</sample>

--- a/golang-dev/skills/testing/exemplar/database-sql.md
+++ b/golang-dev/skills/testing/exemplar/database-sql.md
@@ -1,0 +1,148 @@
+# database/sql — synctest bubbles: matrix runner, wait-before-read, bubble sleeps
+
+Samples: matrix-runner, wait-before-read, bubble-sleep-expiry
+
+Source: `database/sql/sql_test.go` (Go development tree, 1.27 dev, 2026-06).
+Verbatim.
+
+<sample id="matrix-runner" archetypes="harness,lifecycle" source="database/sql/sql_test.go" lines="28-40">
+
+Source: `database/sql/sql_test.go` lines 28-40 (Go 1.27 dev). Verbatim.
+Body elided; lines 41-102 run each driver variant under `t.Run` +
+`synctest.Test`, with `t.Cleanup` closing the DB inside the bubble.
+
+```go
+type requireFeature string
+
+// testDatabase executes f in a synctest bubble.
+//
+// It executes several subtests, each with a database driver supporting
+// a different set of optional interfaces (QueryerContext, etc.).
+//
+// Limit a test to drivers implementing a certain feature by passing
+// a requireFeature option. For example:
+//
+//	// testFunc only executes with drivers which implement Validator.
+//	testDatabase(t, testFunc, requireFeature("Validator"))
+func testDatabase(t *testing.T, f func(t *testing.T, db *DB), opts ...any) {
+```
+
+<highlight archetype="harness">One matrix runner keeps one test body across
+driver variants; options arrive as `...any` resolved by a type switch, and
+`requireFeature` filters variants instead of skipping inside
+bodies.</highlight>
+<highlight archetype="lifecycle">Every test opens its bubble through this one
+composition point, and `t.Cleanup` closes the DB inside the
+bubble.</highlight>
+
+<note>Suite-wide synctest use IS the concurrency testing.</note>
+
+</sample>
+
+<sample id="wait-before-read" archetypes="lifecycle,async-assert" source="database/sql/sql_test.go" lines="382-387">
+
+Source: `database/sql/sql_test.go` lines 382-387 (Go 1.27 dev). Verbatim.
+
+```go
+func (db *DB) numFreeConns() int {
+	synctest.Wait()
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return len(db.freeConn)
+}
+```
+
+<highlight archetype="lifecycle">`synctest.Wait()` runs before the read, so the
+bubble's goroutines settle first; the accessor never races the
+pool.</highlight>
+<highlight archetype="async-assert">Async-state assertions become deterministic
+one-liners; no poll loops, no sleeps.</highlight>
+
+<note>The wait-before-read accessor: wait, then an ordinary locked read.</note>
+
+</sample>
+
+<sample id="bubble-sleep-expiry" archetypes="lifecycle,async-assert" source="database/sql/sql_test.go" lines="3332-3397">
+
+Source: `database/sql/sql_test.go` lines 3332-3397 (Go 1.27 dev). Verbatim.
+
+```go
+func synctestSubtest(t *testing.T, name string, f func(t *testing.T)) {
+	t.Run(name, func(t *testing.T) {
+		synctest.Test(t, f)
+	})
+}
+
+// Issue32530 encounters an issue where a connection may
+// expire right after it comes out of a used connection pool
+// even when a new connection is requested.
+func TestConnExpiresFreshOutOfPool(t *testing.T) {
+	execCases := []struct {
+		expired  bool
+		badReset bool
+	}{
+		{false, false},
+		{true, false},
+		{false, true},
+	}
+
+	for _, ec := range execCases {
+		name := fmt.Sprintf("expired=%t,badReset=%t", ec.expired, ec.badReset)
+		synctestSubtest(t, name, func(t *testing.T) {
+			ctx := t.Context()
+
+			db := newTestDB(t, "magicquery")
+
+			db.SetMaxOpenConns(1)
+
+			db.clearAllConns(t)
+
+			db.SetMaxIdleConns(1)
+			db.SetConnMaxLifetime(10 * time.Second)
+
+			conn, err := db.conn(ctx, alwaysNewConn)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			afterPutConn := make(chan struct{})
+
+			go func() {
+				defer close(afterPutConn)
+
+				conn, err := db.conn(ctx, alwaysNewConn)
+				if err == nil {
+					db.putConn(conn, err, false)
+				} else {
+					t.Errorf("db.conn: %v", err)
+				}
+			}()
+			synctest.Wait()
+
+			if t.Failed() {
+				return
+			}
+
+			synctest.Sleep(11 * time.Second)
+
+			getFakeConn(conn.ci).stickyBad = ec.badReset
+
+			db.putConn(conn, err, true)
+
+			<-afterPutConn
+		})
+	}
+}
+```
+
+<highlight archetype="lifecycle">The body takes `t.Context()`, and the
+goroutine asserts with `t.Errorf` itself (*testing.T is
+concurrency-safe).</highlight>
+<highlight archetype="async-assert">`synctest.Sleep(11 * time.Second)` crosses
+the 10-second lifetime threshold instantly, without real time
+passing.</highlight>
+
+<note>Every move is canonical: the name states the property, `Issue32530`
+demotes to the comment; sub-test names render the case as `Field=Value`.</note>
+
+</sample>

--- a/golang-dev/skills/testing/exemplar/encoding-json.md
+++ b/golang-dev/skills/testing/exemplar/encoding-json.md
@@ -1,0 +1,71 @@
+# encoding/json — the example doc-comment voice
+
+Source: `encoding/json/example_test.go` (Go development tree, 1.27 dev,
+2026-06). Verbatim.
+
+<sample id="example-user-voice" archetypes="example" source="encoding/json/example_test.go" lines="58-86">
+
+Source: `encoding/json/example_test.go` lines 58-86 (Go 1.27 dev). Verbatim.
+
+```go
+// This example uses a Decoder to decode a stream of distinct JSON values.
+func ExampleDecoder() {
+	const jsonStream = `
+	{"Name": "Ed", "Text": "Knock knock."}
+	{"Name": "Sam", "Text": "Who's there?"}
+	{"Name": "Ed", "Text": "Go fmt."}
+	{"Name": "Sam", "Text": "Go fmt who?"}
+	{"Name": "Ed", "Text": "Go fmt yourself!"}
+`
+	type Message struct {
+		Name, Text string
+	}
+	dec := json.NewDecoder(strings.NewReader(jsonStream))
+	for {
+		var m Message
+		if err := dec.Decode(&m); err == io.EOF {
+			break
+		} else if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%s: %s\n", m.Name, m.Text)
+	}
+	// Output:
+	// Ed: Knock knock.
+	// Sam: Who's there?
+	// Ed: Go fmt.
+	// Sam: Go fmt who?
+	// Ed: Go fmt yourself!
+}
+```
+
+<highlight archetype="example">The doc comment reads "This example uses a
+Decoder to decode a stream of distinct JSON values." — it speaks to USERS on
+pkgsite, about the attributed symbol and the scenario, and it does NOT open
+with the function's own name. It never narrates the code, never addresses
+maintainers, never describes the example function itself.</highlight>
+
+<note>The example is also full-length: a five-message stream, a realistic
+decode loop with the `io.EOF` termination idiom users must learn. Do not
+shorten examples to their minimum token count.</note>
+
+</sample>
+
+<sample id="example-self-naming-violation" archetypes="example" source="bufio/example_test.go" lines="36-37">
+
+Source: `bufio/example_test.go` lines 36-37 (Go 1.27 dev). Verbatim.
+The violation, NOT to copy.
+
+```go
+// ExampleWriter_ReadFrom demonstrates how to use the ReadFrom method of Writer.
+func ExampleWriter_ReadFrom() {
+```
+
+<highlight archetype="example">The stdlib itself slips: this doc comment opens
+with the function's own name and narrates the example ("demonstrates how to
+use..."), telling a pkgsite reader nothing the signature does not.</highlight>
+
+<note>Canon is what the Go team practices at its best, not everything it ever
+committed — when you find this shape, write the json form instead.</note>
+
+</sample>

--- a/golang-dev/skills/testing/exemplar/go-parser.md
+++ b/golang-dev/skills/testing/exemplar/go-parser.md
@@ -1,0 +1,96 @@
+# go/parser — expectations at line granularity, inside the fixture
+
+Source: `go/parser/error_test.go` and `go/parser/testdata/commas.src` (Go
+development tree, 1.27 dev, 2026-06). Verbatim.
+
+<sample id="harness-header-doc" archetypes="harness" source="go/parser/error_test.go" lines="5-21">
+
+Source: `go/parser/error_test.go` lines 5-21 (Go 1.27 dev). Verbatim.
+The file-header comment.
+
+```go
+// This file implements a parser test harness. The files in the testdata
+// directory are parsed and the errors reported are compared against the
+// error messages expected in the test files. The test files must end in
+// .src rather than .go so that they are not disturbed by gofmt runs.
+//
+// Expected errors are indicated in the test files by putting a comment
+// of the form /* ERROR "rx" */ immediately following an offending token.
+// The harness will verify that an error matching the regular expression
+// rx is reported at that source position.
+//
+// For instance, the following test file indicates that a "not declared"
+// error should be reported for the undeclared variable x:
+//
+//	package p
+//	func f() {
+//		_ = x /* ERROR "not declared" */ + 1
+//	}
+```
+
+<highlight archetype="harness">A bespoke few-hundred-line harness, written
+once, that turns the parser's user contract into a corpus: the ERROR comment's
+own source position IS the expected diagnostic position, so nobody hand-counts
+line:col at helper-call distance.</highlight>
+
+<note>The header comment teaches the whole convention, with a worked example,
+before any code.</note>
+
+</sample>
+
+<sample id="error-marker-language" archetypes="harness" source="go/parser/error_test.go" lines="61-67">
+
+Source: `go/parser/error_test.go` lines 61-67 (Go 1.27 dev). Verbatim.
+
+```go
+// ERROR comments must be of the form /* ERROR "rx" */ and rx is
+// a regular expression that matches the expected error message.
+// The special form /* ERROR HERE "rx" */ must be used for error
+// messages that appear immediately after a token, rather than at
+// a token's position, and ERROR AFTER means after the comment
+// (e.g. at end of line).
+var errRx = regexp.MustCompile(`^/\* *ERROR *(HERE|AFTER)? *"([^"]*)" *\*/$`)
+```
+
+<highlight archetype="harness">The expectation language is one regular
+expression with two documented refinements (`HERE`, `AFTER`) for positions a
+plain comment cannot express.</highlight>
+
+<note>Grow markers only when a real fixture needs them.</note>
+
+</sample>
+
+<sample id="fixture-inline-expectations" archetypes="golden-fixture,harness" source="go/parser/testdata/commas.src" lines="1-19">
+
+Source: `go/parser/testdata/commas.src`, the complete file (Go 1.27 dev).
+Verbatim.
+
+```go
+// (standard Go copyright header elided)
+
+// Test case for error messages/parser synchronization
+// after missing commas.
+
+package p
+
+var _ = []int{
+	0/* ERROR AFTER "missing ','" */
+}
+
+var _ = []int{
+	0,
+	1,
+	2,
+	3/* ERROR AFTER "missing ','" */
+}
+```
+
+<highlight archetype="golden-fixture">The fixture states its purpose in two
+lines, then the offending token and its expected error sit on the SAME
+line.</highlight>
+<highlight archetype="harness">Sealing is bidirectional in such harnesses: an
+unmatched expectation fails, and so does an unexpected diagnostic.</highlight>
+
+<note>The corpus is the contract, in both directions.</note>
+
+</sample>

--- a/golang-dev/skills/testing/exemplar/hash-maphash.md
+++ b/golang-dev/skills/testing/exemplar/hash-maphash.md
@@ -1,0 +1,138 @@
+# hash/maphash — property-claim names, scenario grain
+
+Samples: property-claim-names, one-invariant-many-paths
+
+Source: `hash/maphash/maphash_test.go` (Go development tree, 1.27 dev, 2026-06).
+Verbatim.
+
+Surface exercised:
+
+```go
+func MakeSeed() Seed
+func Bytes(seed Seed, b []byte) uint64
+func String(seed Seed, s string) uint64
+type Hash struct{ ... }
+    func (h *Hash) Seed() Seed
+    func (h *Hash) SetSeed(seed Seed)
+    func (h *Hash) Sum64() uint64
+```
+
+<sample id="property-claim-names" archetypes="transform" source="hash/maphash/maphash_test.go" lines="20-41">
+
+Source: `hash/maphash/maphash_test.go` lines 20-41 (Go 1.27 dev). Verbatim.
+
+```go
+func TestUnseededHash(t *testing.T) {
+	m := map[uint64]struct{}{}
+	for i := 0; i < 1000; i++ {
+		h := new(Hash)
+		m[h.Sum64()] = struct{}{}
+	}
+	if len(m) < 900 {
+		t.Errorf("empty hash not sufficiently random: got %d, want 1000", len(m))
+	}
+}
+
+func TestSeededHash(t *testing.T) {
+	s := MakeSeed()
+	m := map[uint64]struct{}{}
+	for i := 0; i < 1000; i++ {
+		h := new(Hash)
+		h.SetSeed(s)
+		m[h.Sum64()] = struct{}{}
+	}
+	if len(m) != 1 {
+		t.Errorf("seeded hash is random: got %d, want 1", len(m))
+	}
+```
+
+<highlight archetype="transform">Each name is a claim about the package, not a
+pointer to a symbol: contrasting properties (fresh instances differ; a shared
+seed collapses them to one sum).</highlight>
+
+<note>If you cannot state what breaks when the test fails, the test is
+misnamed.</note>
+
+</sample>
+
+<sample id="one-invariant-many-paths" archetypes="stream,transform" source="hash/maphash/maphash_test.go" lines="44-105">
+
+Source: `hash/maphash/maphash_test.go` lines 44-105 (Go 1.27 dev). Verbatim.
+
+```go
+func TestHashGrouping(t *testing.T) {
+	b := bytes.Repeat([]byte("foo"), 100)
+	hh := make([]*Hash, 7)
+	for i := range hh {
+		hh[i] = new(Hash)
+	}
+	for _, h := range hh[1:] {
+		h.SetSeed(hh[0].Seed())
+	}
+	hh[0].Write(b)
+	hh[1].WriteString(string(b))
+
+	writeByte := func(h *Hash, b byte) {
+		err := h.WriteByte(b)
+		if err != nil {
+			t.Fatalf("WriteByte: %v", err)
+		}
+	}
+	writeSingleByte := func(h *Hash, b byte) {
+		_, err := h.Write([]byte{b})
+		if err != nil {
+			t.Fatalf("Write single byte: %v", err)
+		}
+	}
+	writeStringSingleByte := func(h *Hash, b byte) {
+		_, err := h.WriteString(string([]byte{b}))
+		if err != nil {
+			t.Fatalf("WriteString single byte: %v", err)
+		}
+	}
+
+	for i, x := range b {
+		writeByte(hh[2], x)
+		writeSingleByte(hh[3], x)
+		if i == 0 {
+			writeByte(hh[4], x)
+		} else {
+			writeSingleByte(hh[4], x)
+		}
+		writeStringSingleByte(hh[5], x)
+		if i == 0 {
+			writeByte(hh[6], x)
+		} else {
+			writeStringSingleByte(hh[6], x)
+		}
+	}
+
+	sum := hh[0].Sum64()
+	for i, h := range hh {
+		if sum != h.Sum64() {
+			t.Errorf("hash %d not identical to a single Write", i)
+		}
+	}
+
+	if sum1 := Bytes(hh[0].Seed(), b); sum1 != hh[0].Sum64() {
+		t.Errorf("hash using Bytes not identical to a single Write")
+	}
+
+	if sum1 := String(hh[0].Seed(), string(b)); sum1 != hh[0].Sum64() {
+		t.Errorf("hash using String not identical to a single Write")
+	}
+}
+```
+
+<highlight archetype="stream">ONE test drives seven write paths — mixes of
+`Write`, `WriteString`, and `WriteByte` — and demands they all equal a single
+`Write`'s `Sum64`; the failure message names which path diverged.</highlight>
+<highlight archetype="transform">Top-level `Bytes` and `String` join the same
+invariant, so the pure entry points and the incremental writer are held to one
+answer.</highlight>
+
+<note>The scenario grain to aspire to: the unit of testing is the invariant,
+not the function. No table, no `t.Run`, no comment explaining test mechanics —
+the code reads top to bottom.</note>
+
+</sample>

--- a/golang-dev/skills/testing/exemplar/io.md
+++ b/golang-dev/skills/testing/exemplar/io.md
@@ -1,0 +1,136 @@
+# io — bespoke fakes, contract stated in prose above the assertion
+
+Samples: one-behavior-fakes, regression-to-property
+
+Source: `io/io_test.go` and `io/multi_test.go` (Go development tree, 1.27 dev,
+2026-06). Verbatim. Both files are external
+tests (`package io_test` with `. "io"`).
+
+<sample id="one-behavior-fakes" archetypes="stream" source="io/io_test.go" lines="93-145">
+
+Source: `io/io_test.go` lines 93-145 (Go 1.27 dev). Verbatim.
+
+```go
+// Version of bytes.Buffer that checks whether WriteTo was called or not
+type writeToChecker struct {
+	bytes.Buffer
+	writeToCalled bool
+}
+
+func (wt *writeToChecker) WriteTo(w Writer) (int64, error) {
+	wt.writeToCalled = true
+	return wt.Buffer.WriteTo(w)
+}
+
+// It's preferable to choose WriterTo over ReaderFrom, since a WriterTo can issue one large write,
+// while the ReaderFrom must read until EOF, potentially allocating when running out of buffer.
+// Make sure that we choose WriterTo when both are implemented.
+func TestCopyPriority(t *testing.T) {
+	rb := new(writeToChecker)
+	wb := new(bytes.Buffer)
+	rb.WriteString("hello, world.")
+	Copy(wb, rb)
+	if wb.String() != "hello, world." {
+		t.Errorf("Copy did not work properly")
+	} else if !rb.writeToCalled {
+		t.Errorf("WriteTo was not prioritized over ReadFrom")
+	}
+}
+
+type zeroErrReader struct {
+	err error
+}
+
+func (r zeroErrReader) Read(p []byte) (int, error) {
+	return copy(p, []byte{0}), r.err
+}
+
+type errWriter struct {
+	err error
+}
+
+func (w errWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+// In case a Read results in an error with non-zero bytes read, and
+// the subsequent Write also results in an error, the error from Write
+// is returned, as it is the one that prevented progressing further.
+func TestCopyReadErrWriteErr(t *testing.T) {
+	er, ew := errors.New("readError"), errors.New("writeError")
+	r, w := zeroErrReader{err: er}, errWriter{err: ew}
+	n, err := Copy(w, r)
+	if n != 0 || err != ew {
+		t.Errorf("Copy(zeroErrReader, errWriter) = %d, %v; want 0, writeError", n, err)
+	}
+}
+```
+
+<highlight archetype="stream">Three fakes, each 3-8 lines, each misbehaving in
+exactly one documented way: `writeToChecker` records dispatch, `zeroErrReader`
+reads one byte and errs, `errWriter` only errs. No mock framework earns its
+import against this. And read where the contract lives: the
+WriterTo-over-ReaderFrom priority and the write-error-beats-read-error rule are
+stated in prose immediately above the test that holds them, WITH the rationale
+("a WriterTo can issue one large write").</highlight>
+
+<note>When an assertion is non-obvious, restate the contract clause right
+there.</note>
+
+</sample>
+
+<sample id="regression-to-property" archetypes="stream" source="io/multi_test.go" lines="287-323">
+
+Source: `io/multi_test.go` lines 287-323 (Go 1.27 dev). Verbatim.
+
+```go
+// byteAndEOFReader is a Reader which reads one byte (the underlying
+// byte) and EOF at once in its Read call.
+type byteAndEOFReader byte
+
+func (b byteAndEOFReader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		// Read(0 bytes) is useless. We expect no such useless
+		// calls in this test.
+		panic("unexpected call")
+	}
+	p[0] = byte(b)
+	return 1, EOF
+}
+
+// This used to yield bytes forever; issue 16795.
+func TestMultiReaderSingleByteWithEOF(t *testing.T) {
+	got, err := ReadAll(LimitReader(MultiReader(byteAndEOFReader('a'), byteAndEOFReader('b')), 10))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "ab"
+	if string(got) != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+}
+
+// Test that a reader returning (n, EOF) at the end of a MultiReader
+// chain continues to return EOF on its final read, rather than
+// yielding a (0, EOF).
+func TestMultiReaderFinalEOF(t *testing.T) {
+	r := MultiReader(bytes.NewReader(nil), byteAndEOFReader('a'))
+	buf := make([]byte, 2)
+	n, err := r.Read(buf)
+	if n != 1 || err != EOF {
+		t.Errorf("got %v, %v; want 1, EOF", n, err)
+	}
+}
+```
+
+<highlight archetype="stream">`byteAndEOFReader` is a complete Reader fake in
+one type declaration; the panic inside documents an assumption instead of
+silently tolerating it. `TestMultiReaderFinalEOF` pins the subtle
+`(n, EOF)`-not-`(0, EOF)` clause in prose first, then four lines of
+code.</highlight>
+
+<note>`TestMultiReaderSingleByteWithEOF` is a regression promoted to a
+property: the name states what holds, and "This used to yield bytes forever;
+issue 16795." demotes the bug reference to a comment.</note>
+
+</sample>

--- a/golang-dev/skills/testing/exemplar/strings.md
+++ b/golang-dev/skills/testing/exemplar/strings.md
@@ -1,0 +1,128 @@
+# strings — one runner for a function family; Examples carry the trivial cases
+
+Samples: case-table, family-shared-runner, example-edge-case, bloop-benchmark
+
+Source: `strings/strings_test.go` and `strings/example_test.go` (Go development
+tree, 1.27 dev, 2026-06). Verbatim.
+
+<sample id="case-table" archetypes="transform" source="strings/strings_test.go" lines="60-74">
+
+Source: `strings/strings_test.go` lines 60-74 (Go 1.27 dev). Verbatim.
+The table runs to line 220; elided.
+
+```go
+type IndexTest struct {
+	s   string
+	sep string
+	out int
+}
+
+var indexTests = []IndexTest{
+	{"", "", 0},
+	{"", "a", -1},
+	{"", "foo", -1},
+	{"fo", "foo", -1},
+	{"foo", "foo", 0},
+	{"oofofoofooo", "f", 2},
+	{"oofofoofooo", "foo", 4},
+	{"barfoobarfoo", "foo", 3},
+	// [... ~140 further cases elided; clusters carry comments like
+	//  "cases with one byte strings - test special case in Index()" ...]
+```
+
+<highlight archetype="transform">One `IndexTest` case shape serves the whole
+function family; clusters of cases carry comments like "cases with one byte
+strings - test special case in Index()".</highlight>
+
+<note>Grow the shared table, not the test code: new behavior means new
+rows.</note>
+
+</sample>
+
+<sample id="family-shared-runner" archetypes="transform,harness" source="strings/strings_test.go" lines="222-238">
+
+Source: `strings/strings_test.go` lines 222-238 (Go 1.27 dev). Verbatim.
+
+```go
+// Execute f on each test case.  funcName should be the name of f; it's used
+// in failure reports.
+func runIndexTests(t *testing.T, f func(s, sep string) int, funcName string, testCases []IndexTest) {
+	for _, test := range testCases {
+		actual := f(test.s, test.sep)
+		if actual != test.out {
+			t.Errorf("%s(%q,%q) = %v; want %v", funcName, test.s, test.sep, actual, test.out)
+		}
+	}
+}
+
+func TestIndex(t *testing.T)     { runIndexTests(t, Index, "Index", indexTests) }
+func TestLastIndex(t *testing.T) { runIndexTests(t, LastIndex, "LastIndex", lastIndexTests) }
+func TestIndexAny(t *testing.T)  { runIndexTests(t, IndexAny, "IndexAny", indexAnyTests) }
+func TestLastIndexAny(t *testing.T) {
+	runIndexTests(t, LastIndexAny, "LastIndexAny", lastIndexAnyTests)
+}
+```
+
+<highlight archetype="transform">A pure-function bag is the one API shape where
+tests may name functions — and even then the whole family shares one runner and
+one case shape, so each `TestIndex`-style function is a one-liner binding a
+function to its table.</highlight>
+<highlight archetype="harness">The case-ID (`funcName` plus inputs) appears in
+every failure message, so a plain loop beats `t.Run` ceremony.</highlight>
+
+<note>Do not write a fresh loop body per function.</note>
+
+</sample>
+
+<sample id="example-edge-case" archetypes="example" source="strings/example_test.go" lines="94-100">
+
+Source: `strings/example_test.go` lines 94-100 (Go 1.27 dev). Verbatim.
+
+```go
+func ExampleCount() {
+	fmt.Println(strings.Count("cheese", "e"))
+	fmt.Println(strings.Count("five", "")) // before & after each rune
+	// Output:
+	// 3
+	// 5
+}
+```
+
+<highlight archetype="example">The empty-separator edge case lives in a
+runnable Example, not a test: it asserts (via Output) AND teaches on pkgsite.
+The in-function comment `// before & after each rune` speaks to USERS about
+Count's documented contract — it explains a non-obvious result, never the
+example's own mechanics.</highlight>
+
+<note>These examples carry no doc comments; when you add one, it must not open
+with the function's own name (see the encoding/json exemplar; bufio's
+`ExampleWriter_ReadFrom` doc comment is the violation NOT to copy).</note>
+
+</sample>
+
+<sample id="bloop-benchmark" archetypes="transform" source="strings/strings_test.go" lines="1541-1551">
+
+Source: `strings/strings_test.go` lines 1541-1551 (Go 1.27 dev). Verbatim.
+
+```go
+func BenchmarkReplace(b *testing.B) {
+	for _, tt := range ReplaceTests {
+		desc := fmt.Sprintf("%q %q %q %d", tt.in, tt.old, tt.new, tt.n)
+		b.Run(desc, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				Replace(tt.in, tt.old, tt.new, tt.n)
+			}
+		})
+	}
+}
+```
+
+<highlight archetype="transform">Reuse the correctness table and name
+sub-benchmarks by their inputs, so the benchmark corpus never drifts from the
+tested cases.</highlight>
+
+<note>The modern benchmark shape: `b.ReportAllocs`, and `for b.Loop()` — no
+`b.N`, no timer resets, no assertions smuggled in.</note>
+
+</sample>

--- a/golang-dev/skills/testing/references/concurrency.md
+++ b/golang-dev/skills/testing/references/concurrency.md
@@ -1,0 +1,46 @@
+# Concurrency in tests
+
+Load when a test spawns goroutines, expects panics, hunts races, or the
+package under test is concurrent by nature. The skill's base doctrine
+stands: synctest bubbles on virtual time, the least orchestration, and a
+hang is a valid test failure. Bubble time is exact, so sleep the precise
+moment (expire in a minute: sleep the minute) or the very next quantum
+(`time.Minute + 1`); overshoot margins are a real-time defense, and inside
+a bubble they only signal a hopeful approach to timing.
+
+## Goroutines
+
+Goroutines outside a synctest bubble take a sync.WaitGroup; without one the
+test leaks them. Assert inside the goroutine rather than collecting errors
+or values for the main goroutine to inspect: *testing.T is concurrent-safe,
+and the collection ceremony wastes precious test code. When stressing
+promised concurrent use, provision generously, 64 or 128 or 1024
+goroutines, because 16 may never contend on some hardware.
+
+## What concurrency coverage means
+
+Never hunt races statistically, exercising the package in ways nobody would
+and hoping the detector fires: a misuse that hard to simulate is equally
+hard to hit, and four goroutines hammering Close in hope of a panic prove
+nothing either way. Coverage in the nebulous sense spans the whole suite's
+code, not test titles: a suite whose scenarios run inside synctest bubbles
+is the concurrency testing.
+
+Docs that omit concurrency do not negate it. The delete-unpromised-
+concurrency rule targets tests that assert promises the docs never made;
+an obviously concurrent package, one whose business is goroutines and
+blocking, still gets exercised concurrently through the synctest scenarios
+the suite already runs.
+
+## Panics and invalid inputs
+
+Panics are valid failure conditions of tests: they throw the harness out of
+order and later tests do not progress, but that is a failure, and recovery
+is usually futile unless the panic is expected (then use the recover-helper
+table). When a bug-panic blocks the rest of the work, comment the
+triggering case out to see the work through, and restore it at hand-off,
+never dropping it silently.
+
+Test invalid inputs the package technically accepts: a rate large enough to
+floor the refill interval to zero is invalid even though the constructor
+lets it through.

--- a/golang-dev/skills/testing/references/evaluator-cases.md
+++ b/golang-dev/skills/testing/references/evaluator-cases.md
@@ -1,0 +1,163 @@
+# Evaluator calibration cases
+
+For REVIEW and EVALUATION agents only; writers never load this file. Each
+rule states a ruling in one line (maintainer quotes are verbatim), a `<good>`
+shape a grader must NOT flag, and a `<bad>` near-neighbor it MUST flag, with
+why graders have missed the line before. `file#id` names a `<sample id>` in
+`exemplar/`; invariants match: tags at column 0, `id` first.
+
+<rule id="self-naming-comment">
+"They literally echo the function's name and begins with the test's name - no value added - wasted my time." (maintainer) — no test or example doc comment ever opens with its own function's name.
+<good>encoding-json#example-user-voice — the doc comment opens with the scenario ("This example uses a Decoder..."), never with the function's name.</good>
+<bad>
+// TestReplayPreservesOrder verifies that entries come back in the
+// order they were appended, even across a drain and reload.
+func TestReplayPreservesOrder(t *testing.T) {
+Miss: the comment's content is genuinely useful, so a critic quotes it approvingly as rationale and reads past the opening word; the defect is the first word, not the story. Even the stdlib slips: encoding-json#example-self-naming-violation.
+</bad>
+</rule>
+
+<rule id="rationale-only-nontrivial">
+"Only for the non-trivial tests." (maintainer, striking a grader's every-function doc-comment checkbox) — rationale doc comments are owed by non-trivial tests; a trivial test's silence is correct.
+<good>hash-maphash#property-claim-names — two canon tests, zero doc comments; the claiming names carry it all.</good>
+<bad>
+// TestParseEmpty checks that Parse handles the empty string.
+func TestParseEmpty(t *testing.T) {
+	if _, err := Parse(""); err == nil {
+Miss: a comment on every test reads as diligence, so graders score absence as the defect; flag the vacuous padding, never the silence.
+</bad>
+</rule>
+
+<rule id="package-scenario-name">
+"Go supports package tests, not all of them must be tied to a symbol." (maintainer) — a test named for the whole package, walking the anticipated user flow, is the welcomed scenario shape, not a naming defect.
+<good>
+// One sitting as the anticipated user: enroll, look up, revoke.
+func TestRoster(t *testing.T) {
+	r := roster.New()
+</good>
+<bad>
+func TestRosterEnroll(t *testing.T) {
+func TestRosterLookup(t *testing.T) {
+func TestRosterRevoke(t *testing.T) {
+Miss: the package-named scenario and the receiver-stutter scan look alike; one claims the whole flow, the others staple the type to one method each — a grader has failed the good shape as "a bare type name claiming no property".
+</bad>
+</rule>
+
+<rule id="panic-table-recover">
+"tested panics the best with a **table-driven test** and a **helper** to recover from panics" (maintainer) — the panic table plus recover helper is a sanctioned shape; "bodies are straight-line" does not ban it.
+<good>
+for _, tt := range []struct {
+	n       int
+	invalid string
+}{{0, "zero depth"}, {-1, "negative depth"}} {
+	mustPanic(t, tt.invalid, func() { New(tt.n) })
+}
+</good>
+<bad>
+t.Run(fmt.Sprintf("New(%d)", tt.n), func(t *testing.T) {
+	defer func() { recover() }()
+	New(tt.n)
+Miss: graders reading "straight-line hard-coded bodies" have banned every table; the ban aims at algorithmic bodies and t.Run ceremony repeating inputs in names, not at a table whose failure messages name the input and its invalidity.
+</bad>
+</rule>
+
+<rule id="bubble-sleep">
+"The sleep inside `testing/synctest` is exactly as expected and accurate" (maintainer) — inside a bubble time is virtual, so sleeping is idiomatic, instant, and stable.
+<good>database-sql#bubble-sleep-expiry — `synctest.Sleep(11 * time.Second)` crosses a 10-second threshold instantly inside the bubble.</good>
+<bad>
+go func() { done <- worker.Run() }()
+time.Sleep(50 * time.Millisecond) // let the goroutine get going
+<-done
+Miss: a flat no-sleeps reflex flags both shapes; only the out-of-bubble sleep is synchronization-by-hope — a grader failed a whole suite for sleeps that sat correctly inside bubbles.
+</bad>
+</rule>
+
+<rule id="bubble-exact-timing">
+"inside synctest bubbles, overshooting is a noob move... a hopeful approach to timing" (maintainer) — bubble time is virtual and exact, so sleep the precise moment (expire in a minute: sleep the minute) or the very next quantum (`time.Minute + 1`); wide margins are for real time only.
+<good>
+// Entries live one minute; this is the first instant after expiry.
+time.Sleep(time.Minute + 1)
+if _, ok := c.Get("badge"); ok {
+</good>
+<bad>
+time.Sleep(2 * time.Minute) // generous margin so expiry has surely run
+if _, ok := c.Get("badge"); ok {
+Miss: real-time reflexes credit the margin as flake-proofing (and example-real-sleep rightly blesses it OUTSIDE bubbles), so graders praise as prudence what inside a bubble buys nothing and misstates when the behavior occurs.
+</bad>
+</rule>
+
+<rule id="example-real-sleep">
+Example functions cannot enter synctest bubbles, so a real sleep in an example is correct when it errs only in the safe direction: overshooting a deadline fixed in the past cannot flake. Judge direction, not presence.
+<good>
+// The entry expires 1ms after Put; sleeping 10ms only overshoots,
+// so the miss below cannot flake.
+time.Sleep(10 * time.Millisecond)
+</good>
+<bad>
+time.Sleep(5 * time.Millisecond) // hope the sweep has not run yet
+if _, ok := store.Get("badge"); !ok {
+Miss: "any sleep sits inside a bubble" applied to the letter fails correct examples — a grader failed an otherwise-clean run on exactly this; the flag belongs on window-timing sleeps that must land before or between events, which flake both ways.
+</bad>
+</rule>
+
+<rule id="goroutine-leak">
+A Close that SIGNALS its background goroutine to exit without WAITING for it is a potential-leak finding to raise, never a fix to prescribe: whether a synctest bubble fails when it exits with a live-but-exiting goroutine is still under investigation with the maintainer, so the report flags it and the remedy stays with the owner.
+<good>
+// Close stops the janitor and waits for it to exit.
+close(c.quit)
+c.janitorDone.Wait()
+</good>
+<bad>
+// Close guarantees the janitor will exit.
+close(c.quit) // no wait: the goroutine may outlive Close
+Miss: "guarantees it will exit" reads as a clean shutdown, so graders pass it; the guarantee is not a wait, and a suite whose bubbles exit while the janitor still runs may fail — raise the flag, and do not rewrite the test or the package to resolve it.
+</bad>
+</rule>
+
+<rule id="example-audience">
+"it **narrates** the Go code - which I DESPISE!" (maintainer) — example comments, doc and in-function, render on pkgsite: they speak to users about the attributed symbol and scenario, never narrate code, never address maintainers.
+<good>encoding-json#example-user-voice — scenario-voiced doc comment; the in-function idiom (decode until io.EOF) is what a user must learn.</good>
+<bad>
+// ExampleParse creates a parser, feeds it two records, and
+// prints each one. Keep this in sync with the reader tests.
+func ExampleParse() {
+Miss: the comment is accurate and tidy, so it reads as good documentation; the test is audience, not accuracy — narration and maintainer chatter pass any truthfulness check.
+</bad>
+</rule>
+
+<rule id="prose-subtests">
+"When using sub-tests with more prose-like names, its a smell that these should be one long continuous test" (maintainer) — sub-test names must read like top-level Go test names.
+<good>database-sql#bubble-sleep-expiry — sub-test names render the case as `expired=%t,badReset=%t`: Field=Value, no prose.</good>
+<bad>
+t.Run("returns an error when the stream ends early", func(t *testing.T) {
+t.Run("keeps reading after a blank record", func(t *testing.T) {
+t.Run("stops at the first bad byte", func(t *testing.T) {
+Miss: descriptive prose names look reader-friendly, so graders credit them as clarity; the tell is a name that could never be a Go identifier — those bodies belong inlined into one continuous test.
+</bad>
+</rule>
+
+<rule id="authoring-time-values">
+"that math is performed at coding time and written as results" (maintainer) — bodies hard-code expectations, with an adjacent comment when the arithmetic is delicate.
+<good>strings#case-table — every row writes the answer down ({"oofofoofooo", "foo", 4}); nothing is computed at run time.</good>
+<bad>
+want := workers * perWorker
+for range workers * perWorker {
+	got += <-results
+Miss: derived expectations look DRY and rigorous, but they re-run the arithmetic the code under test performs and inherit its bugs; graders praise the mirroring as thoroughness.
+</bad>
+</rule>
+
+<rule id="owner-only">
+A reviewer or reviser of tests never edits exported source or prose — those are owner-only, whatever any exemplar or fixture shape suggests; drift goes to the report, not the code.
+<good>
+report.md: the doc promises a nil return on empty input; the code
+panics. The suite sides with the prose and stays red; the one-line
+guard is named here. Every non-test file left byte-identical.
+</good>
+<bad>
+-// New panics if depth is not positive.
++// New panics if depth is not between 1 and 1e9, or if width is
++// negative.
+Miss: the edit completes the very fix the critique demanded and can even match an exemplar's shape — a looped run rewrote owner prose citing one; ownership, not correctness, is the test, so diff every non-test file against its input.
+</bad>
+</rule>

--- a/golang-dev/skills/testing/references/examples.md
+++ b/golang-dev/skills/testing/references/examples.md
@@ -1,0 +1,98 @@
+# Runnable examples
+
+Load when an Example function is written, reviewed, or judged. The base
+doctrine stands: a representative runnable example of the anticipated call
+pattern is mandatory per package, and example comments speak to users about
+the attributed symbol and scenario, never narrating code. This file carries
+the rest, because the example archetype matches EVERY package and its
+harness is unlike the test harness: the only assertion is the printed
+output.
+
+## Every character serves users
+
+Doc comment, code, in-function comments, and the Output block all render on
+pkgsite, so an example is user documentation first and a test second: every
+character earns its place by teaching an importer something. Speak about
+USAGE of the package, never about its exported symbols: even a
+single-symbol demo leads into how an importer uses the package, because
+users arrive to compose the API, not to browse a symbol index.
+
+## The Output must demonstrate the claim
+
+An example announces its intent through its doc comment, its name, and its
+inline comments. Whoever judges it validates that the expected Output
+actually demonstrates that intent, because an example whose comment
+promises expiry while its Output shows only insertion publishes a lie on
+pkgsite. (A round-4 catch the maintainer praised: "the example's comment
+promises what its code never shows.")
+
+## All failures must reach the output
+
+The harness has one sense, the printed output compared exactly against the
+expected block, so every possible failure must manifest as output other
+than exactly the expected text: an example that can fail while still
+printing the expected output is worthless to the harness. Route error paths
+to visible prints, and never let a swallowed error leave the happy-path
+text intact.
+
+## Unordered output is a narrow fit
+
+`// Unordered output:` fits very specific cases only, and it is not a
+concurrency magic bullet: it relaxes line ORDER and nothing else, so it
+fits an API whose documented contract fully determines the SET of printed
+values while leaving their order unspecified. The standard tree uses it in
+three packages in total.
+
+<sample id="unordered-output-contract" archetypes="example" source="index/suffixarray/example_test.go" lines="12-22">
+
+Source: `index/suffixarray/example_test.go` lines 12-22 (Go development
+tree, 1.27 dev, 2026-06). Verbatim.
+
+```go
+func ExampleIndex_Lookup() {
+	index := suffixarray.New([]byte("banana"))
+	offsets := index.Lookup([]byte("ana"), -1)
+	for _, off := range offsets {
+		fmt.Println(off)
+	}
+
+	// Unordered output:
+	// 1
+	// 3
+}
+```
+
+<highlight archetype="example">Lookup's doc promises "an unsorted list" of
+every occurrence, so the contract itself fully determines the value set
+("ana" sits at 1 and 3 in "banana") and leaves only the order open. That is
+the whole fit: deterministic values, unspecified order. math/rand/v2's
+ExamplePerm (`example_test.go` lines 99-107) is the same shape: Perm(3)
+must print exactly 0, 1, and 2, in a random order.</highlight>
+
+<note>Neither specimen involves a goroutine. Concurrent failure modes,
+deadlock, lost work, partial output, do not become expected-output
+mismatches just because line order is forgiven, so unordered output buys a
+concurrent example nothing but false confidence.</note>
+
+</sample>
+
+## Real time, in the safe direction
+
+Examples cannot enter synctest bubbles, so their sleeps are real. A sleep
+is valid when it errs only in the safe direction: overshooting a deadline
+fixed in the past cannot flake, and the generous margin that is a noob move
+inside a bubble is exactly right out here, where the scheduler owns the
+clock. Never use a sleep as a synchronization primitive between goroutines,
+because window timing flakes in both directions; a concurrent-heavy pattern
+belongs in a test with a bubble, not in an example. The whole example
+completes within about a second, because it runs in every `go test` of the
+package and pkgsite readers take it as typical usage, not a stress rig.
+
+## Panics may be examples
+
+A trivial panic demonstration can be a runnable example: recover in a
+deferred function, print the recovered value, and the Output block shows a
+user exactly what the misuse costs. The downside is real, because that
+Output block pins the panic text into the contract; the trade works for
+some libraries and not others, so where the message is not a promise, keep
+panics in the test-side panic table instead.

--- a/golang-dev/skills/testing/references/fixtures.md
+++ b/golang-dev/skills/testing/references/fixtures.md
@@ -1,0 +1,30 @@
+# Fixtures and testdata
+
+Load when a test needs file input, long literal data, or malformed cases.
+
+## One reviewable fixture
+
+When a user-facing package does file I/O, keep input and expected output in
+one reviewable fixture, preferring testdata/ files over long string
+constants; cmd/go's script corpus and x/tools' analysistest keep txtar
+fixtures beside their assertions. A fixture must actually exercise the
+format it claims to cover: a sample with uniform spacing and no empty lines
+proves less than it appears to.
+
+Reuse existing fixture fields over inventing purpose-built ones: to test a
+mis-typed value, read an existing name field as an int or a port as a
+duration rather than adding a bad_value field. Reuse is more elegant, and
+the Go team does it well.
+
+## The fixture file speaks
+
+Fixture comments carry real information for both audiences, users and
+maintainers: "Comments are the rest of the line following the # sign",
+never "This is a comment". No warning tone; trust the common sense of
+contributors. A comment spent on a field nobody cares about is a wasted
+comment: when a field is in the fixture for a reason pertaining to the
+test, say that reason there.
+
+Malformed-case files want minimal scaffolding and elegant dogfooding: a
+separated format whose first line states why the case should fail, printed
+when it unexpectedly passes.

--- a/golang-dev/skills/testing/references/harnesses.md
+++ b/golang-dev/skills/testing/references/harnesses.md
@@ -1,0 +1,75 @@
+# Harnesses and testing packages
+
+Load when several implementations or packages need the same scenarios, or
+when designing a helper testing package. The directives here are learned
+from the Go team's own practice: net/http/httptest for harnesses;
+testing/fstest, testing/iotest, and testing/slogtest for verifier-and-fake
+pairs; x/tools' analysistest for the applicative kind.
+
+## When a package earns one
+
+A module's applicative layer earns a bespoke helper testing package, one per
+layer, orchestrating scenarios that respect real user workflows. Several
+implementations of one interface earn a conformance suite that each
+implementation runs from its own tests. Export the harness when third
+parties implement the interface, as httptest and analysistest do; keep it
+internal when only this module's tests consume it, the internal/nettest
+posture. The threshold is the same line helpers cross: when test helpers
+require tests themselves, they have become a testing package, and a
+harness is itself tested, its self-test doubling as usage documentation.
+
+## API shape
+
+One exported entry point, one line of glue, because a consumer's whole
+certification should fit in one test: slogtest.Run(t, newHandler, result)
+and analysistest.Run(t, dir, analyzer) each take the testing handle once
+and own everything after it. The entry point opens with t.Helper(),
+registers teardown with t.Cleanup, converts panics to failures, and routes
+internal logs to t.Logf, so output lands in the consumer's run at the
+consumer's frame. The verifier form takes no *testing.T at all:
+fstest.TestFS(fsys, expected...) error joins every violation with
+errors.Join, leaving the caller to decide what is fatal. Ship the verifier
+with a fake in the same package (fstest.TestFS beside fstest.MapFS),
+because fakes verify consumers while verifiers verify producers. Probe
+optional capabilities by type assertion and check them only when present,
+so richer implementations owe more without minimal ones failing.
+
+Conformance cases replay a user's workflow rather than pin symbols one by
+one, because the contract lives in sequences: iotest.TestReader drives a
+reader through the read, seek, and reread patterns real callers perform,
+and fstest.TestFS walks and reopens the whole tree the way consuming code
+does. Failures surface in the consumer's test run while the expectation
+lives in the harness's source, so route the reader: analysistest reports
+every unmatched expectation at its testdata file and line.
+
+## Discipline
+
+Doc-comment the deliberate non-features and the scope, the way httptest
+documents what must not change after Start, so consumers know what remains
+theirs to configure and to test: the harness owns the shared contract
+only, and implementations test what is specific to their backend. Harness
+defaults mirror production (httptest.Server is the real net/http server on
+a real socket); a consumer depending on customization beyond the default
+depends on a deployment detail that may break in production too. Verifiers
+only tighten, because a tightened verifier failing a lagging
+implementation is the flagged breaking change; fakes only grow richer; an
+exported harness field is never repurposed, deprecate in place and add
+beside it. A human escape hatch costs little and pays off: a flag that
+keeps the failed environment alive for manual poking serves the debugging
+human, not just CI.
+
+## The derivation transfers
+
+go-digitaltwin's enginetest demonstrates these directives in a new world;
+it is not a source of them. Following the canon produced the same shapes.
+The consumer contract is one line of glue, enginetest.Run(t, engine,
+engine), in the engine's own test. Checks are plain functions returning a
+problem string, and only Run touches *testing.T. Because failures surface
+in the engine author's run while cases live in the harness's source, every
+case captures its file:line via runtime.Caller and Run logs "Read the
+source for test-case %v at %v". Altitude splits the canon way: the
+exported conformance suite owns the interface contract while
+internal/dbtest, pure infrastructure, stays internal. None of these are
+rules; each is what the directives above yield when derived afresh. Every
+such package is a whole world; the intent is the same. Learn from the Go
+team's practice, and read enginetest to see the derivation done.

--- a/golang-dev/skills/testing/references/helpers.md
+++ b/golang-dev/skills/testing/references/helpers.md
@@ -1,0 +1,53 @@
+# Test helpers, fakes, and dependencies
+
+Load when a test wants a helper, a fake, or a new dependency, or when
+tabular cases grow construction logic.
+
+## The earning spectrum
+
+Test helpers are a good thing that must not be abused: a premature helper
+saving three lines is a smell that hides bigger misunderstandings. In a
+trivial package, only panic recovery earns one: panics take a table plus a
+recover helper whose failure message names the inputs and their specific
+invalidity from the case struct (exemplar/'s mustPanic is the shape). In
+complex packages, case-construction side functions become legitimate: when
+each tabular case's definition turns complex and multiline, side functions
+that build cases, or single fields of a case, keep the table readable.
+Before inventing a shape, find a proper exemplar in the standard library or
+golang.org/x.
+
+Helper types typically implement an interface the package consumes, with a
+*testing.T field so they assert immediately where the failure is detected
+instead of ferrying values back: an http.Handler that checks fields on the
+http.Request it receives. *testing.T is concurrent-safe, so asserting
+inside the helper is fine wherever it runs.
+
+## Fakes and dependencies
+
+For small dependencies, write a bespoke fake of a few lines: a fake read in
+full keeps the test honest, and no mock framework does. No new third-party
+test dependency (go-cmp included) enters unless the module already carries
+it.
+
+## The method-on-case line
+
+An advanced pattern makes the assertions a method on the case type,
+accepting *testing.T and calling the code under test. It is reserved for
+packages that are much harder to test and require improvised helpers: in an
+ordinary package, even when two functions share a signature, the failure
+messages become awkward to wire, masking the actual test code executed and
+clouding the test's clarity. Do not reach for it while plain straight-line
+bodies suffice.
+
+The line between improvised helpers in the test file and a proper internal
+testing package is drawn when the test helpers require tests themselves; at
+that point build the internal package rather than let an untested harness
+judge the code.
+
+## Placement
+
+Helpers sit after their first usage, never as the opening function: a
+convoluted helper opening the file kills the review, and even landing
+between two tests is better. The file builds complexity as it reads:
+examples first, then the most typical call patterns, the special cases and
+their machinery last.

--- a/golang-dev/skills/testing/references/tables-and-subtests.md
+++ b/golang-dev/skills/testing/references/tables-and-subtests.md
@@ -1,0 +1,41 @@
+# Tables and sub-tests
+
+Load when cases repeat, a table is forming, or a t.Run is about to appear.
+
+## What a table is for
+
+Tabular tests are for the exact same test code run over every case. The
+smell that a table no longer fits: `if` conditions that specialize the test
+code based on some field; that signals two separate tests. When two
+functions mirror each other, merge their expectations into one case struct,
+{s: "hello", n: 3, head: "hel", tail: "llo"}, and drive both from the same
+table, either as two sub-tests or as one loop with two subsequent calls.
+
+Name struct fields once a case carries more than two or three; unnamed
+literals of that size fail golangci-lint's defaults, while one or two
+fields in an anonymous struct earn leniency. Named case types are fine,
+even declared inside the function, doc-commented when the type serves
+several tests. No global test-case slices: a package-level table earns its
+place only when several functions genuinely share it, as when one table
+feeds a test, its benchmark, and a sibling codec's test.
+
+## When a sub-test is worth it
+
+Sub-tests are most appropriate when their names fit, feel, and read like
+top-level test names, reinforced by the fact that they render as Go symbol
+names with no spaces. Prose-like sub-test names are a smell that these
+should be one long continuous test, or that the names need rephrasing; the
+Field=Value syntax names them best: TestReflectionWorks/Kind=integers.
+Inline trivial sub-tests into one linear test, and simplify cumbersome test
+code even at the cost of repeated lines: more lines are preferred when all
+of them are meaningful.
+
+Sub-test names built from descriptions are not always worth it: naming the
+inputs is often enough, never repeated into log names the runner prints
+anyway, and the best names complete a logged sentence ("Load(%q) succeeded
+for a config with %s"). Name a malformed input instead of dumping it,
+because a multiline quoted string in a test log is hard for human eyes to
+parse. Underscores mean nothing in test names except in examples, where
+go-doc reads them to attribute the example to a symbol. Failure messages
+follow the Go wiki's TestComments; many cases of one behavior,
+TableDrivenTests.


### PR DESCRIPTION
Left to itself, an agent asked for tests writes one per exported symbol, comments every function with a restatement of its name, and produces a green suite that pins almost nothing about the package's contract. Asked to review such a suite, it drifts into editing the package instead, because the code under review looks like the best available evidence of what its author meant. This skill closes both gaps: it states what earns a place in a committed _test.go file, and it bounds what a review of one may change.

The doctrine rests on a hierarchy of authority. A package's prose is the most sacred part of its contract, and authority descends from there through the exported signatures and the code down to the existing tests, which are the least golden thing in the room and never the standard. Planning from `go doc -all` before any source file is opened makes that operational, since every collision between the documentation and the implementation surfaces as drift to report rather than behaviour to encode. The unit is the package, exercised as its user through anticipated call patterns, which is what replaces the symbol-by-symbol scan.

Taste is taught by imitation rather than by more sentences. The bundled exemplar carries verbatim, attributed snippets from the Go team's own packages, annotated to say what to copy and why, routed by archetype so a writer reads only the samples matching its package while a reviewer reads the corpus whole. Nothing bundled is canon of its own, which is why an earlier synthetic exemplar was thrown out.

The skill was graded over four rounds against a no-skill baseline of the same model, and 0.5.0 is byte-identical to the version that fourth round measured, so its numbers describe exactly what ships here. Corrections already known to be owed are held for a stacked follow-up rather than folded in, and the eval harness itself stays out of the repository.